### PR TITLE
Editable variables proposal

### DIFF
--- a/packages/2d/src/lib/components/__tests__/mockScene2D.ts
+++ b/packages/2d/src/lib/components/__tests__/mockScene2D.ts
@@ -10,6 +10,7 @@ import {
   startPlayback,
   startScene,
 } from '@canvas-commons/core';
+import {ReadOnlyVariables} from '@canvas-commons/core/lib/scenes/editableVariables';
 import {ReadOnlyTimeEvents} from '@canvas-commons/core/lib/scenes/timeEvents';
 import {afterAll, beforeAll, beforeEach} from 'vitest';
 import {Scene2D, makeScene2D} from '../../scenes';
@@ -33,6 +34,7 @@ export function mockScene2D() {
     size: new Vector2(1920, 1080),
     resolutionScale: 1,
     timeEventsClass: ReadOnlyTimeEvents,
+    variablesClass: ReadOnlyVariables,
     playback: status,
   } as unknown as FullSceneDescription<ThreadGeneratorFactory<View2D>>;
   description.onReplaced = new ValueDispatcher(description);

--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -5,6 +5,7 @@ import {
 } from '../events';
 import {AudioManager, AudioManagerPool, AudioResourceManager} from '../media';
 import {Scene, Sound} from '../scenes';
+import {EditableVariables} from '../scenes/editableVariables';
 import {EditableTimeEvents} from '../scenes/timeEvents';
 import {clamp} from '../tweening';
 import {Vector2} from '../types';
@@ -167,6 +168,7 @@ export class Player {
         size: this.size,
         resolutionScale: this.resolutionScale,
         timeEventsClass: EditableTimeEvents,
+        variablesClass: EditableVariables,
         sharedWebGLContext: this.sharedWebGLContext,
         experimentalFeatures: project.experimentalFeatures,
       });

--- a/packages/core/src/app/Presenter.ts
+++ b/packages/core/src/app/Presenter.ts
@@ -1,5 +1,6 @@
 import {ValueDispatcher} from '../events';
 import type {Scene, Slide} from '../scenes';
+import {ReadOnlyVariables} from '../scenes/editableVariables';
 import {ReadOnlyTimeEvents} from '../scenes/timeEvents';
 import {Vector2} from '../types';
 import {Semaphore} from '../utils';
@@ -91,6 +92,7 @@ export class Presenter {
         size: new Vector2(1920, 1080),
         resolutionScale: 1,
         timeEventsClass: ReadOnlyTimeEvents,
+        variablesClass: ReadOnlyVariables,
         sharedWebGLContext: this.sharedWebGLContext,
         experimentalFeatures: project.experimentalFeatures,
       });

--- a/packages/core/src/app/Renderer.ts
+++ b/packages/core/src/app/Renderer.ts
@@ -1,5 +1,6 @@
 import {EventDispatcher, ValueDispatcher} from '../events';
 import type {Scene, Sound} from '../scenes';
+import {ReadOnlyVariables} from '../scenes/editableVariables';
 import {ReadOnlyTimeEvents} from '../scenes/timeEvents';
 import {clampRemap} from '../tweening';
 import {Vector2} from '../types';
@@ -84,6 +85,7 @@ export class Renderer {
         size: new Vector2(1920, 1080),
         resolutionScale: 1,
         timeEventsClass: ReadOnlyTimeEvents,
+        variablesClass: ReadOnlyVariables,
         sharedWebGLContext: this.sharedWebGLContext,
         experimentalFeatures: project.experimentalFeatures,
       });

--- a/packages/core/src/scenes/GeneratorScene.ts
+++ b/packages/core/src/scenes/GeneratorScene.ts
@@ -26,7 +26,7 @@ import {Shaders} from './Shaders';
 import {Slides} from './Slides';
 import {Sounds} from './Sounds';
 import {Threadable} from './Threadable';
-import {Variables} from './Variables';
+import type {Variables} from './Variables';
 import {TimeEvents} from './timeEvents';
 
 export interface ThreadGeneratorFactory<T> {
@@ -142,7 +142,7 @@ export abstract class GeneratorScene<T>
 
     decorate(this.runnerFactory, threadable(this.name));
     this.timeEvents = new description.timeEventsClass(this);
-    this.variables = new Variables(this);
+    this.variables = new description.variablesClass(this);
     this.shaders = new Shaders(this, description.sharedWebGLContext);
     this.slides = new Slides(this);
     this.sounds = new Sounds(this);

--- a/packages/core/src/scenes/Scene.ts
+++ b/packages/core/src/scenes/Scene.ts
@@ -65,11 +65,11 @@ export interface FullSceneDescription<T = unknown> extends SceneDescription<T> {
   name: string;
   size: Vector2;
   resolutionScale: number;
-  variables: Variables;
   playback: PlaybackStatus;
   logger: Logger;
   onReplaced: ValueDispatcher<FullSceneDescription<T>>;
   timeEventsClass: new (scene: Scene) => TimeEvents;
+  variablesClass: new (scene: Scene) => Variables;
   sharedWebGLContext: SharedWebGLContext;
   experimentalFeatures?: boolean;
 }

--- a/packages/core/src/scenes/SceneMetadata.ts
+++ b/packages/core/src/scenes/SceneMetadata.ts
@@ -1,6 +1,7 @@
 import {MetaField, ObjectMetaField} from '../meta';
+import type {SerializedVariable} from './editableVariables';
 import {Random} from './Random';
-import {SerializedTimeEvent} from './timeEvents';
+import type {SerializedTimeEvent} from './timeEvents';
 
 /**
  * Create a runtime representation of the scene metadata.
@@ -10,6 +11,7 @@ export function createSceneMetadata() {
     version: new MetaField('version', 1),
     timeEvents: new MetaField<SerializedTimeEvent[]>('time events', []),
     seed: new MetaField('seed', Random.createSeed()),
+    properties: new MetaField<SerializedVariable[]>('properties', []),
   });
 }
 

--- a/packages/core/src/scenes/Variables.ts
+++ b/packages/core/src/scenes/Variables.ts
@@ -1,42 +1,119 @@
-import {createSignal, SimpleSignal} from '../signals';
-import type {Scene} from './Scene';
+import type {SubscribableValueEvent} from '../events';
+import type {SimpleSignal} from '../signals';
+import type {
+  EditableVariable,
+  VariableOptions,
+  VariableType,
+} from './editableVariables';
 
-export class Variables {
-  private signals: {[key: string]: SimpleSignal<any>} = {};
-  private variables: Record<string, unknown> = {};
-
-  public constructor(private readonly scene: Scene) {
-    scene.onReset.subscribe(this.handleReset);
-  }
-
+/**
+ * Unified interface for scene variables.
+ *
+ * @remarks
+ * Combines simple key-value variables with typed, editable variables that
+ * appear in the editor UI and persist to `.meta` files. Two implementations
+ * exist: {@link EditableVariables} (editor) and {@link ReadOnlyVariables}
+ * (player/presenter/renderer).
+ */
+export interface Variables {
   /**
-   * Get variable signal if exists or create signal if not
+   * Get a simple variable signal, creating one if it does not yet exist.
    *
    * @param name - The name of the variable.
-   * @param initial - The initial value of the variable. It will be used if the
-   *                  variable was not configured from the outside.
+   * @param initial - The initial value of the variable. Used if the variable
+   *   was not configured from the outside.
    */
-  public get<T>(name: string, initial: T): () => T {
-    this.signals[name] ??= createSignal(this.variables[name] ?? initial);
-    return () => this.signals[name]();
-  }
+  get<T>(name: string, initial: T): () => T;
 
   /**
-   * Update all signals with new project variable values.
+   * Update all signals with new external variable values.
+   *
+   * @remarks
+   * Called by `Player.setVariables` to push external overrides into the
+   * scene. Updates both simple signals created via {@link get} and signal refs
+   * registered via {@link setSignalRef}.
    */
-  public updateSignals(variables: Record<string, unknown>) {
-    this.variables = variables;
-    Object.keys(variables).map(variableName => {
-      if (variableName in this.signals) {
-        this.signals[variableName](variables[variableName]);
-      }
-    });
-  }
+  updateSignals(variables: Record<string, unknown>): void;
 
   /**
-   * Reset all stored signals.
+   * Update the value of an editable variable.
+   *
+   * @param name - The name of the variable.
+   * @param value - The new value.
    */
-  public handleReset = () => {
-    this.signals = {};
-  };
+  set(name: string, value: unknown): void;
+
+  /**
+   * Triggered when editable variables change.
+   *
+   * @eventProperty
+   */
+  get onChanged(): SubscribableValueEvent<EditableVariable[]>;
+
+  /**
+   * Register an editable variable.
+   *
+   * @param name - The unique name of the variable.
+   * @param type - The type of the variable.
+   * @param defaultValue - The default value of the variable.
+   * @param initialTime - The frame-time when the variable was created.
+   * @param options - Optional configuration including presets and hidden flag.
+   *
+   * @returns The current value of the variable (external override, persisted,
+   *   or default).
+   *
+   * @internal
+   */
+  register<T>(
+    name: string,
+    type: VariableType,
+    defaultValue: T,
+    initialTime: number,
+    options?: VariableOptions<T>,
+  ): T;
+
+  /**
+   * Get the signal reference for a registered variable.
+   *
+   * @param name - The name of the variable.
+   *
+   * @returns The signal, or undefined if no signal has been registered.
+   */
+  getSignalRef(name: string): SimpleSignal<unknown> | undefined;
+
+  /**
+   * Store a signal reference for a registered variable.
+   *
+   * @param name - The name of the variable.
+   * @param signal - The signal backing this variable.
+   * @param transform - An optional transform matrix function for gizmo display.
+   * @param offset - An optional function computing a display offset from the
+   *   current value. Applied only for drawing and hit-testing, not drag deltas.
+   */
+  setSignalRef(
+    name: string,
+    signal: SimpleSignal<unknown>,
+    transform?: () => DOMMatrix,
+    offset?: (value: unknown) => {x: number; y: number},
+  ): void;
+
+  /**
+   * Get the transform matrix function for a registered variable.
+   *
+   * @param name - The name of the variable.
+   *
+   * @returns The transform function, or undefined if none was provided.
+   */
+  getTransform(name: string): (() => DOMMatrix) | undefined;
+
+  /**
+   * Get the display offset function for a registered variable.
+   *
+   * @param name - The name of the variable.
+   *
+   * @returns The offset function, or undefined if none was provided.
+   */
+  getOffset(
+    name: string,
+  ): ((value: unknown) => {x: number; y: number}) | undefined;
 }

--- a/packages/core/src/scenes/editableVariables/AbstractVariables.ts
+++ b/packages/core/src/scenes/editableVariables/AbstractVariables.ts
@@ -1,0 +1,95 @@
+import {ValueDispatcher} from '../../events';
+import {createSignal, SimpleSignal} from '../../signals';
+import type {PossibleBBox} from '../../types/BBox';
+import {BBox} from '../../types/BBox';
+import type {PossibleVector2} from '../../types/Vector';
+import {Vector2} from '../../types/Vector';
+import type {EditableVariable, VariableType} from './EditableVariable';
+
+/**
+ * Shared base for {@link EditableVariables} and {@link ReadOnlyVariables}.
+ *
+ * @remarks
+ * Contains the common signal management, transform/offset maps, and value
+ * normalization logic. Subclasses implement `register`, `set`, and lifecycle
+ * hooks specific to their context (editor vs. player/presenter).
+ */
+export abstract class AbstractVariables {
+  public get onChanged() {
+    return this.properties.subscribable;
+  }
+
+  protected readonly properties = new ValueDispatcher<EditableVariable[]>([]);
+  protected signals: Record<string, SimpleSignal<unknown>> = {};
+  protected externalVariables: Record<string, unknown> = {};
+  protected signalRefs = new Map<string, SimpleSignal<unknown>>();
+  protected transforms = new Map<string, () => DOMMatrix>();
+  protected offsets = new Map<
+    string,
+    (value: unknown) => {x: number; y: number}
+  >();
+
+  public get<T>(name: string, initial: T): () => T {
+    this.signals[name] ??= createSignal<unknown>(
+      this.externalVariables[name] ?? initial,
+    );
+    return () => this.signals[name]() as T;
+  }
+
+  public updateSignals(variables: Record<string, unknown>) {
+    this.externalVariables = variables;
+    for (const [name, value] of Object.entries(variables)) {
+      if (name in this.signals) {
+        this.signals[name](value);
+      }
+      const ref = this.signalRefs.get(name);
+      if (ref) {
+        ref(value);
+      }
+    }
+  }
+
+  public getSignalRef(name: string): SimpleSignal<unknown> | undefined {
+    return this.signalRefs.get(name);
+  }
+
+  public setSignalRef(
+    name: string,
+    signal: SimpleSignal<unknown>,
+    transform?: () => DOMMatrix,
+    offset?: (value: unknown) => {x: number; y: number},
+  ) {
+    this.signalRefs.set(name, signal);
+    if (transform) {
+      this.transforms.set(name, transform);
+    }
+    if (offset) {
+      this.offsets.set(name, offset);
+    }
+  }
+
+  public getTransform(name: string): (() => DOMMatrix) | undefined {
+    return this.transforms.get(name);
+  }
+
+  public getOffset(
+    name: string,
+  ): ((value: unknown) => {x: number; y: number}) | undefined {
+    return this.offsets.get(name);
+  }
+
+  protected normalizeValue(type: VariableType, value: unknown): unknown {
+    switch (type) {
+      case 'vector2': {
+        const v = new Vector2(value as PossibleVector2);
+        return v.serialize();
+      }
+      case 'bbox': {
+        const b = new BBox(value as PossibleBBox);
+        return b.serialize();
+      }
+      default:
+        return value;
+    }
+  }
+}

--- a/packages/core/src/scenes/editableVariables/EditableVariable.ts
+++ b/packages/core/src/scenes/editableVariables/EditableVariable.ts
@@ -1,0 +1,70 @@
+/**
+ * The supported types for editable variables.
+ */
+export type VariableType =
+  | 'number'
+  | 'string'
+  | 'boolean'
+  | 'vector2'
+  | 'bbox'
+  | 'color';
+
+/**
+ * A labeled preset value.
+ */
+export interface LabeledPreset<T> {
+  label: string;
+  value: T;
+}
+
+/**
+ * A preset value, either bare or with a label.
+ */
+export type Preset<T> = T | LabeledPreset<T>;
+
+/**
+ * Options for editable variable registration.
+ */
+export interface VariableOptions<T = unknown> {
+  presets?: Preset<T>[];
+  hidden?: boolean;
+}
+
+/**
+ * Represents an editable variable at runtime.
+ */
+export interface EditableVariable<T = unknown> {
+  /**
+   * The unique name of the variable.
+   */
+  name: string;
+  /**
+   * The type of the variable, used for rendering the appropriate editor
+   * controls.
+   */
+  type: VariableType;
+  /**
+   * The current value of the variable.
+   */
+  value: T;
+  /**
+   * The default value of the variable as specified in code.
+   */
+  defaultValue: T;
+  /**
+   * The frame-time when the variable was registered.
+   */
+  initialTime: number;
+  /**
+   * Stack trace at the moment of registration.
+   */
+  stack?: string;
+  /**
+   * Presets defined in code for quick selection in the editor.
+   */
+  presets?: Preset<T>[];
+  /**
+   * Whether this variable should be hidden from the timeline UI.
+   */
+  hidden?: boolean;
+}

--- a/packages/core/src/scenes/editableVariables/EditableVariables.ts
+++ b/packages/core/src/scenes/editableVariables/EditableVariables.ts
@@ -1,0 +1,180 @@
+import type {Scene} from '../Scene';
+import type {Variables} from '../Variables';
+import {AbstractVariables} from './AbstractVariables';
+import type {
+  EditableVariable,
+  VariableOptions,
+  VariableType,
+} from './EditableVariable';
+import type {SerializedVariable} from './SerializedVariable';
+
+/**
+ * Manages editable variables during editing.
+ *
+ * @remarks
+ * Merges simple key-value variable signals with typed, persisted, editor-UI
+ * editable variables into a single implementation.
+ */
+export class EditableVariables extends AbstractVariables implements Variables {
+  private registeredProperties = new Map<string, EditableVariable>();
+  private lookup = new Map<string, EditableVariable>();
+  private collisionLookup = new Set<string>();
+  private previousReference: SerializedVariable[] = [];
+  private didPropertiesChange = false;
+
+  public constructor(private readonly scene: Scene) {
+    super();
+    this.previousReference = scene.meta.properties.get();
+    this.load(this.previousReference);
+
+    scene.onReloaded.subscribe(this.handleReload);
+    scene.onRecalculated.subscribe(this.handleRecalculated);
+    scene.onReset.subscribe(this.handleReset);
+    scene.meta.properties.onChanged.subscribe(this.handleMetaChanged, false);
+  }
+
+  public set(name: string, value: unknown) {
+    const property = this.lookup.get(name);
+    if (!property) {
+      return;
+    }
+
+    const updated: EditableVariable = {
+      ...property,
+      value: this.normalizeValue(property.type, value),
+    };
+    this.lookup.set(name, updated);
+    this.registeredProperties.set(name, updated);
+    this.properties.current = [...this.registeredProperties.values()];
+    this.didPropertiesChange = true;
+    this.scene.reload();
+  }
+
+  public register<T>(
+    name: string,
+    type: VariableType,
+    defaultValue: T,
+    initialTime: number,
+    options?: VariableOptions<T>,
+  ): T {
+    if (this.collisionLookup.has(name)) {
+      this.scene.logger.error({
+        message: `Variable name "${name}" has already been used for another editable variable.`,
+        stack: new Error().stack,
+      });
+      return defaultValue;
+    }
+
+    const normalizedDefault = this.normalizeValue(type, defaultValue) as T;
+
+    this.collisionLookup.add(name);
+    let property = this.lookup.get(name);
+    if (!property) {
+      this.didPropertiesChange = true;
+      property = {
+        name,
+        type,
+        value: normalizedDefault,
+        defaultValue: normalizedDefault,
+        initialTime,
+        stack: new Error().stack,
+        presets: options?.presets,
+        hidden: options?.hidden,
+      };
+      this.lookup.set(name, property);
+    } else {
+      let changed = false;
+      const newProperty = {...property};
+
+      newProperty.stack = new Error().stack;
+
+      if (newProperty.type !== type) {
+        newProperty.type = type;
+        changed = true;
+      }
+
+      if (newProperty.defaultValue !== normalizedDefault) {
+        newProperty.defaultValue = normalizedDefault;
+        changed = true;
+      }
+
+      if (newProperty.initialTime !== initialTime) {
+        newProperty.initialTime = initialTime;
+        changed = true;
+      }
+
+      newProperty.presets = options?.presets;
+      newProperty.hidden = options?.hidden;
+
+      if (changed) {
+        property = newProperty;
+        this.lookup.set(name, property);
+      }
+    }
+
+    this.registeredProperties.set(name, property);
+
+    return property.value as T;
+  }
+
+  private handleReload = () => {
+    this.registeredProperties.clear();
+    this.collisionLookup.clear();
+    this.signalRefs.clear();
+    this.transforms.clear();
+    this.offsets.clear();
+    this.signals = {};
+  };
+
+  private handleRecalculated = () => {
+    this.properties.current = [...this.registeredProperties.values()];
+
+    if (
+      this.didPropertiesChange ||
+      (this.previousReference?.length ?? 0) !== this.properties.current.length
+    ) {
+      this.didPropertiesChange = false;
+      this.previousReference = [...this.registeredProperties.values()].map(
+        property => ({
+          name: property.name,
+          type: property.type,
+          value: property.value,
+          initialTime: property.initialTime,
+        }),
+      );
+      this.scene.meta.properties.set(this.previousReference);
+    }
+  };
+
+  private handleReset = () => {
+    this.collisionLookup.clear();
+  };
+
+  private handleMetaChanged = (data: SerializedVariable[]) => {
+    if (data === this.previousReference) return;
+    this.previousReference = data;
+    this.load(data);
+    this.scene.reload();
+  };
+
+  private load(properties: SerializedVariable[]) {
+    for (const property of properties) {
+      if (typeof property.name !== 'string') {
+        continue;
+      }
+
+      const normalized = this.normalizeValue(property.type, property.value);
+      const previous = this.lookup.get(property.name);
+      this.lookup.set(property.name, {
+        name: property.name,
+        type: property.type,
+        value: normalized,
+        defaultValue: previous?.defaultValue ?? normalized,
+        initialTime: property.initialTime ?? previous?.initialTime ?? 0,
+        stack: previous?.stack,
+        presets: previous?.presets,
+        hidden: previous?.hidden,
+      });
+    }
+  }
+}

--- a/packages/core/src/scenes/editableVariables/ReadOnlyVariables.ts
+++ b/packages/core/src/scenes/editableVariables/ReadOnlyVariables.ts
@@ -1,0 +1,58 @@
+import type {Scene} from '../Scene';
+import type {Variables} from '../Variables';
+import {AbstractVariables} from './AbstractVariables';
+import type {VariableType} from './EditableVariable';
+
+/**
+ * Manages editable variables during rendering and presentation.
+ *
+ * @remarks
+ * Values are read-only: external overrides via {@link updateSignals} take
+ * precedence, followed by persisted `.meta` values, then defaults. The
+ * {@link set} method is a no-op because there is no editor to persist changes.
+ */
+export class ReadOnlyVariables extends AbstractVariables implements Variables {
+  private lookup = new Map<string, unknown>();
+
+  public constructor(private readonly scene: Scene) {
+    super();
+    scene.onReloaded.subscribe(this.handleReload);
+    scene.onReset.subscribe(this.handleReset);
+  }
+
+  public set() {
+    // no-op: read-only in player/presenter
+  }
+
+  public register<T>(name: string, type: VariableType, defaultValue: T): T {
+    let value = this.lookup.get(name);
+    if (value === undefined) {
+      const external = this.externalVariables[name];
+      if (external !== undefined) {
+        value = this.normalizeValue(type, external);
+      } else {
+        const property = this.scene.meta.properties
+          .get()
+          .find(p => p.name === name);
+        value = property
+          ? this.normalizeValue(type, property.value)
+          : this.normalizeValue(type, defaultValue);
+      }
+      this.lookup.set(name, value);
+    }
+
+    return value as T;
+  }
+
+  private handleReload = () => {
+    this.lookup.clear();
+    this.signalRefs.clear();
+    this.transforms.clear();
+    this.offsets.clear();
+    this.signals = {};
+  };
+
+  private handleReset = () => {
+    this.signals = {};
+  };
+}

--- a/packages/core/src/scenes/editableVariables/SerializedVariable.ts
+++ b/packages/core/src/scenes/editableVariables/SerializedVariable.ts
@@ -1,0 +1,23 @@
+import type {VariableType} from './EditableVariable';
+
+/**
+ * Represents an editable variable stored in a meta file.
+ */
+export interface SerializedVariable {
+  /**
+   * {@inheritDoc EditableVariable.name}
+   */
+  name: string;
+  /**
+   * {@inheritDoc EditableVariable."type"}
+   */
+  type: VariableType;
+  /**
+   * {@inheritDoc EditableVariable.value}
+   */
+  value: unknown;
+  /**
+   * {@inheritDoc EditableVariable.initialTime}
+   */
+  initialTime: number;
+}

--- a/packages/core/src/scenes/editableVariables/index.ts
+++ b/packages/core/src/scenes/editableVariables/index.ts
@@ -1,0 +1,5 @@
+export * from './AbstractVariables';
+export * from './EditableVariable';
+export * from './EditableVariables';
+export * from './ReadOnlyVariables';
+export * from './SerializedVariable';

--- a/packages/core/src/scenes/index.ts
+++ b/packages/core/src/scenes/index.ts
@@ -16,3 +16,4 @@ export * from './Slides';
 export * from './Sounds';
 export * from './Threadable';
 export * from './Variables';
+export * from './editableVariables';

--- a/packages/core/src/scenes/timeEvents/EditableTimeEvents.ts
+++ b/packages/core/src/scenes/timeEvents/EditableTimeEvents.ts
@@ -73,11 +73,7 @@ export class EditableTimeEvents implements TimeEvents {
       let changed = false;
       const newEvent = {...event};
 
-      const stack = new Error().stack;
-      if (newEvent.stack !== stack) {
-        newEvent.stack = stack;
-        changed = true;
-      }
+      newEvent.stack = new Error().stack;
 
       if (newEvent.initialTime !== initialTime) {
         newEvent.initialTime = initialTime;

--- a/packages/core/src/types/BBox.ts
+++ b/packages/core/src/types/BBox.ts
@@ -1,5 +1,12 @@
-import {CompoundSignal, CompoundSignalContext, SignalValue} from '../signals';
+import type {VariableOptions} from '../scenes/editableVariables';
+import {
+  CompoundSignal,
+  CompoundSignalContext,
+  SignalValue,
+  SimpleSignal,
+} from '../signals';
 import {InterpolationFunction, arcLerp, map} from '../tweening';
+import {useScene, useThread} from '../utils';
 import {PossibleMatrix2D} from './Matrix2D';
 import {PossibleSpacing, Spacing} from './Spacing';
 import {Type, WebGLConvertible} from './Type';
@@ -25,6 +32,11 @@ export type RectSignal<T> = CompoundSignal<
   T
 >;
 
+export interface BBoxVariableOptions extends VariableOptions<PossibleBBox> {
+  transform?: () => DOMMatrix;
+  offset?: (value: SerializedBBox) => {x: number; y: number};
+}
+
 export class BBox implements Type, WebGLConvertible {
   public static readonly symbol = Symbol.for('@canvas-commons/core/types/Rect');
 
@@ -43,6 +55,42 @@ export class BBox implements Type, WebGLConvertible {
       initial,
       interpolation,
     ).toSignal();
+  }
+
+  /**
+   * Register an editable bbox variable and get a signal backed by the
+   * persisted value.
+   *
+   * @param name - A unique name for this variable within the scene.
+   * @param initial - The default value if no persisted value exists.
+   * @param options - Optional configuration including presets, hidden,
+   *   transform for gizmo display, and offset function.
+   *
+   * @returns A {@link RectSignal} containing the current value.
+   */
+  public static createEditableVariable(
+    name: string,
+    initial?: PossibleBBox,
+    options?: BBoxVariableOptions,
+  ): RectSignal<void> {
+    const scene = useScene();
+    const thread = useThread();
+    const {transform, offset, ...rest} = options ?? {};
+    const value = scene.variables.register(
+      name,
+      'bbox',
+      initial,
+      thread.time(),
+      rest,
+    );
+    const signal = BBox.createSignal(value as PossibleBBox);
+    scene.variables.setSignalRef(
+      name,
+      signal as SimpleSignal<unknown>,
+      transform,
+      offset as ((value: unknown) => {x: number; y: number}) | undefined,
+    );
+    return signal;
   }
 
   public static lerp(

--- a/packages/core/src/types/Color.ts
+++ b/packages/core/src/types/Color.ts
@@ -1,6 +1,8 @@
 import {Color, ColorSpace, InterpolationMode, mix} from 'chroma-js';
-import {Signal, SignalContext, SignalValue} from '../signals';
+import type {VariableOptions} from '../scenes/editableVariables';
+import {Signal, SignalContext, SignalValue, SimpleSignal} from '../signals';
 import type {InterpolationFunction} from '../tweening';
+import {useScene, useThread} from '../utils';
 import type {Type, WebGLConvertible} from './Type';
 
 export type SerializedColor = string;
@@ -36,6 +38,11 @@ declare module 'chroma-js' {
     createSignal(
       initial?: SignalValue<PossibleColor>,
       interpolation?: InterpolationFunction<ColorInterface>,
+    ): ColorSignal<void>;
+    createEditableVariable(
+      name: string,
+      initial?: PossibleColor,
+      options?: VariableOptions<PossibleColor>,
     ): ColorSignal<void>;
   }
   interface ChromaStatic {
@@ -102,6 +109,25 @@ const ExtendedColor: typeof Color = (() => {
       undefined,
       value => new Color(value),
     ).toSignal();
+  };
+
+  Color.createEditableVariable = (
+    name: string,
+    initial?: PossibleColor,
+    options?: VariableOptions<PossibleColor>,
+  ): ColorSignal<void> => {
+    const scene = useScene();
+    const thread = useThread();
+    const value = scene.variables.register(
+      name,
+      'color',
+      initial,
+      thread.time(),
+      options,
+    );
+    const signal = Color.createSignal(value as PossibleColor);
+    scene.variables.setSignalRef(name, signal as SimpleSignal<unknown>);
+    return signal;
   };
 
   Color.prototype.toSymbol = () => {

--- a/packages/core/src/types/Vector.ts
+++ b/packages/core/src/types/Vector.ts
@@ -1,6 +1,8 @@
+import type {VariableOptions} from '../scenes/editableVariables';
 import {
   Signal,
   SignalValue,
+  SimpleSignal,
   Vector2Signal,
   Vector2SignalContext,
 } from '../signals';
@@ -10,10 +12,15 @@ import {
   clamp,
   map,
 } from '../tweening/interpolationFunctions';
-import {DEG2RAD, RAD2DEG} from '../utils';
+import {DEG2RAD, RAD2DEG, useScene, useThread} from '../utils';
 import {Matrix2D, PossibleMatrix2D} from './Matrix2D';
 import {Direction, Origin} from './Origin';
 import {EPSILON, Type, WebGLConvertible} from './Type';
+
+export interface Vector2VariableOptions
+  extends VariableOptions<PossibleVector2> {
+  transform?: () => DOMMatrix;
+}
 
 export type SerializedVector2<T = number> = {
   x: T;
@@ -84,6 +91,41 @@ export class Vector2 implements Type, WebGLConvertible {
       interpolation,
       owner,
     ).toSignal();
+  }
+
+  /**
+   * Register an editable vector2 variable and get a signal backed by the
+   * persisted value.
+   *
+   * @param name - A unique name for this variable within the scene.
+   * @param initial - The default value if no persisted value exists.
+   * @param options - Optional configuration including presets, hidden, and
+   *   transform for gizmo display.
+   *
+   * @returns A `Vector2Signal` containing the current value.
+   */
+  public static createEditableVariable(
+    name: string,
+    initial?: PossibleVector2,
+    options?: Vector2VariableOptions,
+  ): Vector2Signal<void> {
+    const scene = useScene();
+    const thread = useThread();
+    const {transform, ...rest} = options ?? {};
+    const value = scene.variables.register(
+      name,
+      'vector2',
+      initial,
+      thread.time(),
+      rest,
+    );
+    const signal = Vector2.createSignal(value as PossibleVector2);
+    scene.variables.setSignalRef(
+      name,
+      signal as SimpleSignal<unknown>,
+      transform,
+    );
+    return signal;
   }
 
   public static lerp(from: Vector2, to: Vector2, value: number | Vector2) {

--- a/packages/core/src/utils/createEditableVariable.ts
+++ b/packages/core/src/utils/createEditableVariable.ts
@@ -1,0 +1,51 @@
+import type {VariableOptions, VariableType} from '../scenes/editableVariables';
+import {SignalContext, SimpleSignal} from '../signals';
+import {deepLerp} from '../tweening';
+import {useScene} from './useScene';
+import {useThread} from './useThread';
+
+/**
+ * Register a primitive editable variable and get a signal backed by the
+ * persisted value.
+ *
+ * @remarks
+ * Creates a signal whose initial value comes from the editor's persisted
+ * metadata. The variable will appear in the editor's timeline as a pill that
+ * can be selected and edited through the inspector.
+ *
+ * For complex types use the type-specific factories instead:
+ * - `Vector2.createEditableVariable` for vector2 variables
+ * - `BBox.createEditableVariable` for bbox variables
+ * - `Color.createEditableVariable` for color variables
+ *
+ * @example
+ * ```ts
+ * const radius = createEditableVariable('radius', 42);
+ * yield* circle().radius(radius(), 1);
+ * ```
+ *
+ * @param name - A unique name for this variable within the scene.
+ * @param defaultValue - The default value if no persisted value exists.
+ * @param options - Optional configuration including presets and hidden flag.
+ *
+ * @returns A signal containing the current (possibly persisted) value.
+ */
+export function createEditableVariable<T extends string | number | boolean>(
+  name: string,
+  defaultValue: T,
+  options?: VariableOptions<T>,
+): SimpleSignal<T> {
+  const scene = useScene();
+  const thread = useThread();
+  const type = typeof defaultValue as VariableType;
+  const currentValue = scene.variables.register(
+    name,
+    type,
+    defaultValue,
+    thread.time(),
+    options,
+  );
+  const signal = new SignalContext<T, T>(currentValue, deepLerp).toSignal();
+  scene.variables.setSignalRef(name, signal as SimpleSignal<unknown>);
+  return signal;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './ExperimentalError';
 export * from './Semaphore';
 export * from './beginSlide';
 export * from './capitalize';
+export * from './createEditableVariable';
 export * from './createRef';
 export * from './createRefArray';
 export * from './createRefMap';

--- a/packages/ui/src/components/controls/Controls.module.scss
+++ b/packages/ui/src/components/controls/Controls.module.scss
@@ -134,11 +134,17 @@
 .numberInputLabel {
   position: relative;
 
-  div {
+  > input {
+    width: 100%;
+  }
+
+  > div {
     position: absolute;
     left: 8px;
-    bottom: 0;
+    top: 50%;
+    transform: translateY(-50%);
     font-family: var(--font-family-mono);
+    pointer-events: none;
   }
 }
 
@@ -362,6 +368,48 @@
       box-shadow: 0 0 0 2px white inset;
     }
   }
+}
+
+.fieldColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 100%;
+  min-width: 0;
+}
+
+.presetRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  flex: 1 1 100%;
+  min-width: 0;
+}
+
+.presetChip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--radius);
+  background-color: var(--input-background);
+  color: rgba(255, 255, 255, 0.6);
+  font-family: var(--font-family-mono);
+  font-size: 11px;
+  padding: 2px 8px;
+  height: 22px;
+  cursor: pointer;
+  min-width: 22px;
+
+  &:hover {
+    background-color: var(--input-background-hover);
+  }
+}
+
+.presetSwatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
 }
 
 .slider {

--- a/packages/ui/src/components/controls/NumberInput.tsx
+++ b/packages/ui/src/components/controls/NumberInput.tsx
@@ -32,84 +32,88 @@ export function NumberInput({
   const [startX, setStartX] = useState(0);
   const currentValue = editedValue ?? value;
 
-  return (
-    <>
-      <input
-        type={'number'}
-        ref={inputRef}
-        min={min}
-        max={max}
-        step={step}
-        lang={'en'}
-        value={currentValue?.toFixed(decimalPlaces)}
-        onChangeCapture={() => onChange?.(parseFloat(inputRef.current.value))}
-        onPointerDown={event => {
-          if (
-            document.activeElement !== inputRef.current &&
-            event.button === MouseButton.Left
-          ) {
-            event.preventDefault();
-            event.stopPropagation();
-            event.currentTarget.setPointerCapture(event.pointerId);
+  const inputEl = (
+    <input
+      type={'number'}
+      ref={inputRef}
+      min={min}
+      max={max}
+      step={step}
+      lang={'en'}
+      value={currentValue?.toFixed(decimalPlaces)}
+      onChangeCapture={() => onChange?.(parseFloat(inputRef.current.value))}
+      onPointerDown={event => {
+        if (
+          document.activeElement !== inputRef.current &&
+          event.button === MouseButton.Left
+        ) {
+          event.preventDefault();
+          event.stopPropagation();
+          event.currentTarget.setPointerCapture(event.pointerId);
 
-            setStartX(event.clientX);
-            setEditedValue(value);
-          }
-        }}
-        onPointerMove={event => {
-          if (
-            document.activeElement !== inputRef.current &&
-            event.currentTarget.hasPointerCapture(event.pointerId)
-          ) {
-            event.preventDefault();
-            event.stopPropagation();
+          setStartX(event.clientX);
+          setEditedValue(value);
+        }
+      }}
+      onPointerMove={event => {
+        if (
+          document.activeElement !== inputRef.current &&
+          event.currentTarget.hasPointerCapture(event.pointerId)
+        ) {
+          event.preventDefault();
+          event.stopPropagation();
 
-            if (Math.abs(startX - event.clientX) > 5) {
-              inputRef.current.requestPointerLock();
-            }
-          } else if (
-            document.pointerLockElement === inputRef.current &&
-            // ignore very large jumps in movement, as they often result
-            // from mouse acceleration issues
-            Math.abs(event.movementX) < 100
-          ) {
-            setEditedValue(
-              clamp(min, max, currentValue + event.movementX * step),
-            );
+          if (Math.abs(startX - event.clientX) > 5) {
+            inputRef.current.requestPointerLock();
           }
-        }}
-        onPointerUp={event => {
-          if (event.button === MouseButton.Left) {
-            event.stopPropagation();
-            event.currentTarget.releasePointerCapture(event.pointerId);
+        } else if (
+          document.pointerLockElement === inputRef.current &&
+          // ignore very large jumps in movement, as they often result
+          // from mouse acceleration issues
+          Math.abs(event.movementX) < 100
+        ) {
+          setEditedValue(
+            clamp(min, max, currentValue + event.movementX * step),
+          );
+        }
+      }}
+      onPointerUp={event => {
+        if (event.button === MouseButton.Left) {
+          event.stopPropagation();
+          event.currentTarget.releasePointerCapture(event.pointerId);
 
-            if (document.pointerLockElement === inputRef.current) {
-              document.exitPointerLock();
-              onChange?.(editedValue);
-            } else if (document.activeElement !== inputRef.current) {
-              inputRef.current.select();
-            }
+          if (document.pointerLockElement === inputRef.current) {
+            document.exitPointerLock();
+            onChange?.(editedValue);
+          } else if (document.activeElement !== inputRef.current) {
+            inputRef.current.select();
+          }
 
-            setEditedValue(null);
-          }
-        }}
-        onKeyDown={event => {
-          if (event.key === 'Enter') {
-            inputRef.current.blur();
-          }
-          if (event.key === 'Escape') {
-            inputRef.current.value = value.toFixed(decimalPlaces);
-            inputRef.current.blur();
-          }
-        }}
-        className={clsx(styles.input, styles.numberInput)}
-        {...props}
-      />
-      {label && (
-        <div className={styles.numberInputLabel}>
-          <div>{label}</div>
-        </div>
-      )}
-    </>
+          setEditedValue(null);
+        }
+      }}
+      onKeyDown={event => {
+        if (event.key === 'Enter') {
+          inputRef.current.blur();
+        }
+        if (event.key === 'Escape') {
+          inputRef.current.value = value.toFixed(decimalPlaces);
+          inputRef.current.blur();
+        }
+      }}
+      className={clsx(styles.input, styles.numberInput)}
+      {...props}
+    />
   );
+
+  if (label) {
+    return (
+      <div className={styles.numberInputLabel}>
+        {inputEl}
+        <div>{label}</div>
+      </div>
+    );
+  }
+
+  return inputEl;
 }

--- a/packages/ui/src/components/controls/PresetPicker.tsx
+++ b/packages/ui/src/components/controls/PresetPicker.tsx
@@ -1,0 +1,58 @@
+import type {
+  LabeledPreset,
+  Preset,
+  VariableType,
+} from '@canvas-commons/core/lib/scenes/editableVariables';
+import styles from './Controls.module.scss';
+
+function resolvePreset<T>(preset: Preset<T>): {label: string; value: T} {
+  if (typeof preset === 'object' && preset !== null && 'label' in preset) {
+    const labeled = preset as LabeledPreset<T>;
+    return {label: labeled.label, value: labeled.value};
+  }
+  return {label: String(preset), value: preset as T};
+}
+
+interface PresetPickerProps {
+  presets: Preset<unknown>[];
+  type: VariableType;
+  onSelect: (value: unknown) => void;
+  onPreview?: (value: unknown) => void;
+  onPreviewEnd?: () => void;
+}
+
+export function PresetPicker({
+  presets,
+  type,
+  onSelect,
+  onPreview,
+  onPreviewEnd,
+}: PresetPickerProps) {
+  return (
+    <div className={styles.presetRow}>
+      {presets.map((preset, i) => {
+        const {label, value} = resolvePreset(preset);
+        const isColor = type === 'color' && typeof value === 'string';
+        return (
+          <button
+            key={i}
+            className={styles.presetChip}
+            title={label}
+            onPointerEnter={() => onPreview?.(value)}
+            onPointerLeave={() => onPreviewEnd?.()}
+            onClick={() => onSelect(value)}
+          >
+            {isColor ? (
+              <div
+                className={styles.presetSwatch}
+                style={{backgroundColor: value}}
+              />
+            ) : (
+              label
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui/src/components/controls/index.ts
+++ b/packages/ui/src/components/controls/index.ts
@@ -11,6 +11,7 @@ export * from './Label';
 export * from './NumberInput';
 export * from './NumberInputSelect';
 export * from './Pill';
+export * from './PresetPicker';
 export * from './ReadOnlyInput';
 export * from './Select';
 export * from './Separator';

--- a/packages/ui/src/components/fields/EditablePropertyField.tsx
+++ b/packages/ui/src/components/fields/EditablePropertyField.tsx
@@ -1,0 +1,127 @@
+import type {EditableVariable} from '@canvas-commons/core/lib/scenes/editableVariables';
+import {Input, NumberInput} from '../controls';
+import styles from '../controls/Controls.module.scss';
+
+interface EditablePropertyFieldProps {
+  property: EditableVariable;
+  onChange: (value: unknown) => void;
+  onPreview?: (value: unknown) => void;
+  onPreviewEnd?: () => void;
+}
+
+export function EditablePropertyField({
+  property,
+  onChange,
+  onPreview,
+  onPreviewEnd,
+}: EditablePropertyFieldProps) {
+  switch (property.type) {
+    case 'number':
+      return (
+        <NumberInput
+          value={property.value as number}
+          onChange={onChange}
+          decimalPlaces={2}
+          step={1}
+        />
+      );
+    case 'string':
+      return (
+        <Input
+          value={property.value as string}
+          onChangeCapture={e => onChange((e.target as HTMLInputElement).value)}
+        />
+      );
+    case 'boolean':
+      return (
+        <input
+          type="checkbox"
+          checked={property.value as boolean}
+          onChange={e => onChange((e.target as HTMLInputElement).checked)}
+        />
+      );
+    case 'vector2': {
+      const value = property.value as {x: number; y: number};
+      return (
+        <div className={styles.fieldColumn}>
+          <NumberInput
+            value={value?.x ?? 0}
+            onChange={x => onChange({...value, x})}
+            decimalPlaces={2}
+            step={1}
+            label="X"
+          />
+          <NumberInput
+            value={value?.y ?? 0}
+            onChange={y => onChange({...value, y})}
+            decimalPlaces={2}
+            step={1}
+            label="Y"
+          />
+        </div>
+      );
+    }
+    case 'bbox': {
+      const value = property.value as {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      };
+      return (
+        <div className={styles.fieldColumn}>
+          <NumberInput
+            value={value?.x ?? 0}
+            onChange={x => onChange({...value, x})}
+            decimalPlaces={2}
+            step={1}
+            label="X"
+          />
+          <NumberInput
+            value={value?.y ?? 0}
+            onChange={y => onChange({...value, y})}
+            decimalPlaces={2}
+            step={1}
+            label="Y"
+          />
+          <NumberInput
+            value={value?.width ?? 0}
+            onChange={width => onChange({...value, width})}
+            decimalPlaces={2}
+            step={1}
+            label="W"
+          />
+          <NumberInput
+            value={value?.height ?? 0}
+            onChange={height => onChange({...value, height})}
+            decimalPlaces={2}
+            step={1}
+            label="H"
+          />
+        </div>
+      );
+    }
+    case 'color':
+      return (
+        <Input
+          type="color"
+          value={property.value as string}
+          onInput={
+            onPreview
+              ? (e: Event) => onPreview((e.target as HTMLInputElement).value)
+              : undefined
+          }
+          onChangeCapture={e => {
+            onChange((e.target as HTMLInputElement).value);
+            onPreviewEnd?.();
+          }}
+        />
+      );
+    default:
+      return (
+        <span style={{opacity: 0.5, padding: '0 8px'}}>
+          {JSON.stringify(property.value)}
+        </span>
+      );
+  }
+}

--- a/packages/ui/src/components/fields/index.ts
+++ b/packages/ui/src/components/fields/index.ts
@@ -1,5 +1,6 @@
 export * from './AutoField';
 export * from './ColorField';
+export * from './EditablePropertyField';
 export * from './Expandable';
 export * from './Layout';
 export * from './NumberField';

--- a/packages/ui/src/components/timeline/PropertyGroup.tsx
+++ b/packages/ui/src/components/timeline/PropertyGroup.tsx
@@ -1,0 +1,32 @@
+import type {Scene} from '@canvas-commons/core';
+import {useTimelineContext} from '../../contexts';
+import {useSubscribableValue} from '../../hooks';
+import {PropertyPill} from './PropertyPill';
+
+interface PropertyGroupProps {
+  scene: Scene;
+}
+
+export function PropertyGroup({scene}: PropertyGroupProps) {
+  const {firstVisibleFrame, lastVisibleFrame} = useTimelineContext();
+  const properties = useSubscribableValue(scene.variables.onChanged);
+  const cached = useSubscribableValue(scene.onCacheChanged);
+  const isVisible =
+    cached.lastFrame >= firstVisibleFrame &&
+    cached.firstFrame <= lastVisibleFrame;
+
+  return (
+    <>
+      {isVisible &&
+        properties
+          .filter(p => !p.hidden)
+          .map(property => (
+            <PropertyPill
+              key={property.name}
+              property={property}
+              scene={scene}
+            />
+          ))}
+    </>
+  );
+}

--- a/packages/ui/src/components/timeline/PropertyPill.tsx
+++ b/packages/ui/src/components/timeline/PropertyPill.tsx
@@ -1,0 +1,46 @@
+import styles from './Timeline.module.scss';
+
+import type {Scene} from '@canvas-commons/core';
+import type {EditableVariable} from '@canvas-commons/core/lib/scenes/editableVariables';
+import {useApplication, useTimelineContext} from '../../contexts';
+import {PROPERTY_INSPECTOR_KEY} from '../viewport/PropertyInspector';
+
+interface PropertyPillProps {
+  property: EditableVariable;
+  scene: Scene;
+}
+
+export function PropertyPill({property, scene}: PropertyPillProps) {
+  const {framesToPercents} = useTimelineContext();
+  const {inspection} = useApplication();
+
+  const inspected = inspection.value;
+  const isSelected =
+    inspected.key === PROPERTY_INSPECTOR_KEY &&
+    (inspected.payload as {sceneName: string; propertyName: string})
+      ?.sceneName === scene.name &&
+    (inspected.payload as {sceneName: string; propertyName: string})
+      ?.propertyName === property.name;
+
+  return (
+    <div
+      className={`${styles.propertyPill} ${isSelected ? styles.selected : ''}`}
+      data-name={property.name}
+      data-type={property.type}
+      onPointerDown={e => {
+        if (e.button !== 0) return;
+        e.stopPropagation();
+        inspection.value = {
+          key: PROPERTY_INSPECTOR_KEY,
+          payload: {sceneName: scene.name, propertyName: property.name},
+        };
+      }}
+      style={{
+        left: `${framesToPercents(
+          scene.firstFrame +
+            scene.playback.secondsToFrames(property.initialTime),
+        )}%`,
+      }}
+    />
+  );
+}

--- a/packages/ui/src/components/timeline/PropertyTrack.tsx
+++ b/packages/ui/src/components/timeline/PropertyTrack.tsx
@@ -1,0 +1,16 @@
+import styles from './Timeline.module.scss';
+
+import {useScenes} from '../../hooks';
+import {PropertyGroup} from './PropertyGroup';
+
+export function PropertyTrack() {
+  const scenes = useScenes();
+
+  return (
+    <div className={styles.propertyTrack}>
+      {scenes.map(scene => (
+        <PropertyGroup key={scene.name} scene={scene} />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/timeline/Timeline.module.scss
+++ b/packages/ui/src/components/timeline/Timeline.module.scss
@@ -173,6 +173,52 @@
   padding: 4px 0;
 }
 
+.propertyTrack {
+  position: relative;
+  height: 32px;
+  padding: 4px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+.propertyPill {
+  position: absolute;
+  height: 24px;
+  padding: 2px 4px;
+  cursor: pointer;
+
+  &::before {
+    content: attr(data-name);
+    display: block;
+    border-radius: 12px;
+    padding: 0 8px;
+    color: rgba(255, 255, 255, 0.87);
+    font-size: var(--font-size-small);
+    font-weight: bold;
+    background-color: var(--surface-color-light);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.32);
+    white-space: nowrap;
+    line-height: 20px;
+  }
+
+  &:hover,
+  &:active {
+    &::before {
+      box-shadow: 0 0 0 2px var(--theme) inset;
+    }
+    z-index: 1;
+  }
+
+  &.selected {
+    &::before {
+      box-shadow: 0 0 0 2px var(--theme) inset;
+    }
+    z-index: 1;
+  }
+}
+
 .labelClip {
   position: absolute;
   height: 32px;

--- a/packages/ui/src/components/timeline/Timeline.tsx
+++ b/packages/ui/src/components/timeline/Timeline.tsx
@@ -27,6 +27,7 @@ import {borderHighlight} from '../animations';
 import {AudioTrack} from './AudioTrack';
 import {LabelTrack} from './LabelTrack';
 import {Playhead} from './Playhead';
+import {PropertyTrack} from './PropertyTrack';
 import {RangeSelector} from './RangeSelector';
 import {SceneTrack} from './SceneTrack';
 import {Timestamps} from './Timestamps';
@@ -39,7 +40,7 @@ const MAX_FRAME_SIZE = 128;
 
 export function Timeline() {
   const shortcutRef = useSurfaceShortcuts<HTMLDivElement>(TIMELINE_SHORTCUTS);
-  const {player, meta} = useApplication();
+  const {player, meta, inspection} = useApplication();
   const {range} = useSharedSettings();
   const containerRef = useRef<HTMLDivElement>();
   const playheadRef = useRef<HTMLDivElement>();
@@ -255,6 +256,7 @@ export function Timeline() {
           }}
           onPointerDown={event => {
             if (event.button === MouseButton.Left) {
+              inspection.value = {key: '', payload: null};
               event.preventDefault();
               event.currentTarget.setPointerCapture(event.pointerId);
               playheadRef.current.style.display = 'none';
@@ -314,6 +316,7 @@ export function Timeline() {
               <div className={styles.trackContainer}>
                 <SceneTrack />
                 <LabelTrack />
+                <PropertyTrack />
                 <AudioTrack />
               </div>
               <Playhead seeking={seeking} />

--- a/packages/ui/src/components/viewport/EditorPreview.tsx
+++ b/packages/ui/src/components/viewport/EditorPreview.tsx
@@ -21,6 +21,10 @@ import {Coordinates} from './Coordinates';
 import {Inspector} from './Inspector';
 import {OverlayCanvas} from './OverlayCanvas';
 import {PreviewStage} from './PreviewStage';
+import {
+  PropertyGizmosOverlay,
+  usePropertyGizmoDrawHook,
+} from './PropertyGizmos';
 import styles from './Viewport.module.scss';
 
 const ZOOM_SPEED = 0.1;
@@ -49,8 +53,10 @@ export function EditorPreview() {
 
   const inspector = useMemo(() => <Inspector />, []);
   const drawHooks = useMemo(
-    () =>
-      plugins.map(plugin => plugin.previewOverlay?.drawHook).filter(Boolean),
+    () => [
+      ...plugins.map(plugin => plugin.previewOverlay?.drawHook).filter(Boolean),
+      usePropertyGizmoDrawHook,
+    ],
     [plugins],
   );
 
@@ -188,6 +194,7 @@ export function EditorPreview() {
             const Component = plugin.previewOverlay?.component;
             return Component ? <Component>{children}</Component> : children;
           }, undefined as ComponentChildren)}
+          <PropertyGizmosOverlay />
         </div>
         <div className={clsx(styles.overlay, styles.controls)}>
           <Select

--- a/packages/ui/src/components/viewport/OverlayCanvas.tsx
+++ b/packages/ui/src/components/viewport/OverlayCanvas.tsx
@@ -29,6 +29,10 @@ export function OverlayCanvas({
     [renderCount],
   );
 
+  useSubscribable(player.onRender, () => setRenderCount(renderCount + 1), [
+    renderCount,
+  ]);
+
   useLayoutEffect(() => {
     contextRef.current ??= canvasRef.current.getContext('2d');
     const ctx = contextRef.current;

--- a/packages/ui/src/components/viewport/PropertyGizmos.tsx
+++ b/packages/ui/src/components/viewport/PropertyGizmos.tsx
@@ -1,0 +1,503 @@
+import type {Scene} from '@canvas-commons/core';
+import type {EditableVariable} from '@canvas-commons/core/lib/scenes/editableVariables';
+import {useMemo, useRef} from 'preact/hooks';
+import {useApplication, useViewportContext} from '../../contexts';
+import {useScenes, useViewportMatrix} from '../../hooks';
+import type {PluginDrawFunction} from '../../plugin';
+import {OverlayWrapper} from '../../plugin';
+import {PROPERTY_INSPECTOR_KEY} from './PropertyInspector';
+
+const HANDLE_RADIUS = 6;
+const HANDLE_STROKE = 2;
+const BBOX_HANDLE_SIZE = 8;
+const HIT_SLOP = 8;
+
+interface GizmoEntry {
+  property: EditableVariable;
+  scene: Scene;
+}
+
+type BBoxHandle =
+  | 'topLeft'
+  | 'topRight'
+  | 'bottomLeft'
+  | 'bottomRight'
+  | 'body';
+
+interface DragState {
+  propertyName: string;
+  scene: Scene;
+  type: 'vector2' | 'bbox';
+  handle: 'center' | BBoxHandle;
+  startValue: Record<string, number>;
+  startPointer: {x: number; y: number};
+  startOffset: {x: number; y: number};
+}
+
+function getPropertyTransformMatrix(
+  viewportMatrix: DOMMatrix,
+  scene: Scene,
+  transform?: () => DOMMatrix,
+): DOMMatrix {
+  if (!transform) {
+    return viewportMatrix;
+  }
+  try {
+    return viewportMatrix.multiply(transform());
+  } catch (e) {
+    scene.logger.warn(`Editable property transform failed: ${e}`);
+    return viewportMatrix;
+  }
+}
+
+function collectGizmoEntries(
+  scenes: Scene[],
+  currentScene: Scene | undefined,
+  types: string[],
+): GizmoEntry[] {
+  const result: GizmoEntry[] = [];
+  for (const scene of scenes) {
+    if (scene !== currentScene) continue;
+    const current: EditableVariable[] = scene.variables.onChanged.current ?? [];
+    for (const property of current) {
+      if (!types.includes(property.type)) continue;
+      result.push({property, scene});
+    }
+  }
+  return result;
+}
+
+function drawVector2Gizmo(ctx: CanvasRenderingContext2D, point: DOMPoint) {
+  ctx.beginPath();
+  ctx.arc(point.x, point.y, HANDLE_RADIUS, 0, Math.PI * 2);
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.3)';
+  ctx.fill();
+  ctx.strokeStyle = 'white';
+  ctx.lineWidth = HANDLE_STROKE;
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo(point.x - HANDLE_RADIUS * 1.5, point.y);
+  ctx.lineTo(point.x + HANDLE_RADIUS * 1.5, point.y);
+  ctx.moveTo(point.x, point.y - HANDLE_RADIUS * 1.5);
+  ctx.lineTo(point.x, point.y + HANDLE_RADIUS * 1.5);
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.6)';
+  ctx.lineWidth = 1;
+  ctx.stroke();
+}
+
+function drawBBoxCornerHandle(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+) {
+  const half = BBOX_HANDLE_SIZE / 2;
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+  ctx.fillRect(x - half, y - half, BBOX_HANDLE_SIZE, BBOX_HANDLE_SIZE);
+  ctx.strokeStyle = 'white';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(x - half, y - half, BBOX_HANDLE_SIZE, BBOX_HANDLE_SIZE);
+}
+
+function drawBBoxGizmo(
+  ctx: CanvasRenderingContext2D,
+  topLeft: DOMPoint,
+  topRight: DOMPoint,
+  bottomRight: DOMPoint,
+  bottomLeft: DOMPoint,
+) {
+  ctx.beginPath();
+  ctx.moveTo(topLeft.x, topLeft.y);
+  ctx.lineTo(topRight.x, topRight.y);
+  ctx.lineTo(bottomRight.x, bottomRight.y);
+  ctx.lineTo(bottomLeft.x, bottomLeft.y);
+  ctx.closePath();
+  ctx.strokeStyle = 'white';
+  ctx.lineWidth = HANDLE_STROKE;
+  ctx.stroke();
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.05)';
+  ctx.fill();
+
+  drawBBoxCornerHandle(ctx, topLeft.x, topLeft.y);
+  drawBBoxCornerHandle(ctx, topRight.x, topRight.y);
+  drawBBoxCornerHandle(ctx, bottomRight.x, bottomRight.y);
+  drawBBoxCornerHandle(ctx, bottomLeft.x, bottomLeft.y);
+}
+
+export function usePropertyGizmoDrawHook(): PluginDrawFunction {
+  const {player, inspection} = useApplication();
+  const scenes = useScenes();
+
+  const allEntries = useMemo(
+    () =>
+      collectGizmoEntries(scenes, player.playback.currentScene, [
+        'vector2',
+        'bbox',
+      ]),
+    [scenes, player.playback.currentScene],
+  );
+
+  const inspected = inspection.value;
+  const activeEntries = useMemo(() => {
+    if (inspected.key !== PROPERTY_INSPECTOR_KEY) return [];
+    const payload = inspected.payload as {
+      sceneName: string;
+      propertyName: string;
+    };
+    return allEntries.filter(
+      e =>
+        e.scene.name === payload.sceneName &&
+        e.property.name === payload.propertyName,
+    );
+  }, [allEntries, inspected]);
+
+  return useMemo(
+    () => (ctx: CanvasRenderingContext2D, matrix: DOMMatrix) => {
+      for (const {property, scene} of activeEntries) {
+        const transform = scene.variables.getTransform(property.name);
+        const finalMatrix = getPropertyTransformMatrix(
+          matrix,
+          scene,
+          transform,
+        );
+        const signalRef = scene.variables.getSignalRef(property.name);
+        const rawValue = signalRef ? signalRef() : property.value;
+
+        if (property.type === 'vector2') {
+          const value = rawValue as {x: number; y: number};
+          if (
+            !value ||
+            typeof value.x !== 'number' ||
+            typeof value.y !== 'number'
+          ) {
+            continue;
+          }
+          const point = finalMatrix.transformPoint(
+            new DOMPoint(value.x, value.y),
+          );
+          drawVector2Gizmo(ctx, point);
+        } else if (property.type === 'bbox') {
+          const value = rawValue as {
+            x: number;
+            y: number;
+            width: number;
+            height: number;
+          };
+          if (!value || typeof value.x !== 'number') {
+            continue;
+          }
+          const offsetFn = scene.variables.getOffset(property.name);
+          const off = offsetFn ? offsetFn(value) : {x: 0, y: 0};
+          const cx = value.x + off.x;
+          const cy = value.y + off.y;
+          const topLeft = finalMatrix.transformPoint(new DOMPoint(cx, cy));
+          const topRight = finalMatrix.transformPoint(
+            new DOMPoint(cx + value.width, cy),
+          );
+          const bottomRight = finalMatrix.transformPoint(
+            new DOMPoint(cx + value.width, cy + value.height),
+          );
+          const bottomLeft = finalMatrix.transformPoint(
+            new DOMPoint(cx, cy + value.height),
+          );
+          drawBBoxGizmo(ctx, topLeft, topRight, bottomRight, bottomLeft);
+        }
+      }
+    },
+    [activeEntries],
+  );
+}
+
+function hitTestVector2(
+  pointerX: number,
+  pointerY: number,
+  value: {x: number; y: number},
+  matrix: DOMMatrix,
+): boolean {
+  const point = matrix.transformPoint(new DOMPoint(value.x, value.y));
+  const dx = pointerX - point.x;
+  const dy = pointerY - point.y;
+  return dx * dx + dy * dy <= (HANDLE_RADIUS + HIT_SLOP) ** 2;
+}
+
+function isPointInQuad(
+  px: number,
+  py: number,
+  a: DOMPoint,
+  b: DOMPoint,
+  c: DOMPoint,
+  d: DOMPoint,
+): boolean {
+  const cross = (ax: number, ay: number, bx: number, by: number) =>
+    ax * by - ay * bx;
+  const sides = [
+    cross(b.x - a.x, b.y - a.y, px - a.x, py - a.y),
+    cross(c.x - b.x, c.y - b.y, px - b.x, py - b.y),
+    cross(d.x - c.x, d.y - c.y, px - c.x, py - c.y),
+    cross(a.x - d.x, a.y - d.y, px - d.x, py - d.y),
+  ];
+  return sides.every(s => s >= 0) || sides.every(s => s <= 0);
+}
+
+function hitTestBBox(
+  pointerX: number,
+  pointerY: number,
+  value: {x: number; y: number; width: number; height: number},
+  matrix: DOMMatrix,
+  offset?: {x: number; y: number},
+): BBoxHandle | null {
+  const off = offset ?? {x: 0, y: 0};
+  const cx = value.x + off.x;
+  const cy = value.y + off.y;
+  const corners: [BBoxHandle, DOMPoint][] = [
+    ['topLeft', matrix.transformPoint(new DOMPoint(cx, cy))],
+    ['topRight', matrix.transformPoint(new DOMPoint(cx + value.width, cy))],
+    [
+      'bottomRight',
+      matrix.transformPoint(new DOMPoint(cx + value.width, cy + value.height)),
+    ],
+    ['bottomLeft', matrix.transformPoint(new DOMPoint(cx, cy + value.height))],
+  ];
+
+  const threshold = BBOX_HANDLE_SIZE / 2 + HIT_SLOP;
+  for (const [handle, point] of corners) {
+    if (
+      Math.abs(pointerX - point.x) <= threshold &&
+      Math.abs(pointerY - point.y) <= threshold
+    ) {
+      return handle;
+    }
+  }
+
+  if (
+    isPointInQuad(
+      pointerX,
+      pointerY,
+      corners[0][1],
+      corners[1][1],
+      corners[2][1],
+      corners[3][1],
+    )
+  ) {
+    return 'body';
+  }
+
+  return null;
+}
+
+function screenToProperty(
+  dx: number,
+  dy: number,
+  viewportMatrix: DOMMatrix,
+  transform?: () => DOMMatrix,
+): {x: number; y: number} {
+  let inverseMatrix = viewportMatrix.inverse();
+  if (transform) {
+    try {
+      inverseMatrix = transform().inverse().multiply(inverseMatrix);
+    } catch {
+      // Fall through with viewport-only inverse
+    }
+  }
+  const origin = inverseMatrix.transformPoint(new DOMPoint(0, 0));
+  const delta = inverseMatrix.transformPoint(new DOMPoint(dx, dy));
+  return {x: delta.x - origin.x, y: delta.y - origin.y};
+}
+
+export function PropertyGizmosOverlay() {
+  const {player, inspection} = useApplication();
+  const scenes = useScenes();
+  const state = useViewportContext();
+  const viewportMatrix = useViewportMatrix();
+  const dragState = useRef<DragState | null>(null);
+
+  const allEntries = useMemo(
+    () =>
+      collectGizmoEntries(scenes, player.playback.currentScene, [
+        'vector2',
+        'bbox',
+      ]),
+    [scenes, player.playback.currentScene],
+  );
+
+  const inspected = inspection.value;
+  const activeEntries = useMemo(() => {
+    if (inspected.key !== PROPERTY_INSPECTOR_KEY) return [];
+    const payload = inspected.payload as {
+      sceneName: string;
+      propertyName: string;
+    };
+    return allEntries.filter(
+      e =>
+        e.scene.name === payload.sceneName &&
+        e.property.name === payload.propertyName,
+    );
+  }, [allEntries, inspected]);
+
+  return (
+    <OverlayWrapper
+      onPointerDown={event => {
+        if (event.button !== 0 || event.shiftKey) return;
+
+        const pointerX = event.x - state.rect.x;
+        const pointerY = event.y - state.rect.y;
+
+        for (const {property, scene} of activeEntries) {
+          const transform = scene.variables.getTransform(property.name);
+          const finalMatrix = getPropertyTransformMatrix(
+            viewportMatrix,
+            scene,
+            transform,
+          );
+
+          if (property.type === 'vector2') {
+            const value = property.value as {x: number; y: number};
+            if (!value || typeof value.x !== 'number') continue;
+            if (hitTestVector2(pointerX, pointerY, value, finalMatrix)) {
+              event.stopPropagation();
+              event.currentTarget.setPointerCapture(event.pointerId);
+              dragState.current = {
+                propertyName: property.name,
+                scene,
+                type: 'vector2',
+                handle: 'center',
+                startValue: {...value},
+                startPointer: {x: event.x, y: event.y},
+                startOffset: {x: 0, y: 0},
+              };
+              return;
+            }
+          } else if (property.type === 'bbox') {
+            const value = property.value as {
+              x: number;
+              y: number;
+              width: number;
+              height: number;
+            };
+            if (!value || typeof value.x !== 'number') continue;
+            const offsetFn = scene.variables.getOffset(property.name);
+            const off = offsetFn ? offsetFn(value) : undefined;
+            const handle = hitTestBBox(
+              pointerX,
+              pointerY,
+              value,
+              finalMatrix,
+              off,
+            );
+            if (handle) {
+              event.stopPropagation();
+              event.currentTarget.setPointerCapture(event.pointerId);
+              dragState.current = {
+                propertyName: property.name,
+                scene,
+                type: 'bbox',
+                handle,
+                startValue: {...value},
+                startPointer: {x: event.x, y: event.y},
+                startOffset: off ?? {x: 0, y: 0},
+              };
+              return;
+            }
+          }
+        }
+      }}
+      onPointerMove={event => {
+        if (
+          !dragState.current ||
+          !event.currentTarget.hasPointerCapture(event.pointerId)
+        ) {
+          return;
+        }
+        event.stopPropagation();
+
+        const drag = dragState.current;
+        const totalDx = event.x - drag.startPointer.x;
+        const totalDy = event.y - drag.startPointer.y;
+        const transform = drag.scene.variables.getTransform(drag.propertyName);
+        const delta = screenToProperty(
+          totalDx,
+          totalDy,
+          viewportMatrix,
+          transform,
+        );
+
+        const signal = drag.scene.variables.getSignalRef(drag.propertyName);
+        if (!signal) return;
+
+        if (drag.type === 'vector2') {
+          signal({
+            x: drag.startValue.x + delta.x,
+            y: drag.startValue.y + delta.y,
+          });
+        } else if (drag.type === 'bbox') {
+          const sv = drag.startValue;
+          const so = drag.startOffset;
+          const sdx = sv.x + so.x;
+          const sdy = sv.y + so.y;
+
+          let rx = sdx;
+          let ry = sdy;
+          let rw = sv.width;
+          let rh = sv.height;
+          switch (drag.handle) {
+            case 'body':
+              rx = sdx + delta.x;
+              ry = sdy + delta.y;
+              break;
+            case 'topLeft':
+              rx = sdx + delta.x;
+              ry = sdy + delta.y;
+              rw = sv.width - delta.x;
+              rh = sv.height - delta.y;
+              break;
+            case 'topRight':
+              ry = sdy + delta.y;
+              rw = sv.width + delta.x;
+              rh = sv.height - delta.y;
+              break;
+            case 'bottomLeft':
+              rx = sdx + delta.x;
+              rw = sv.width - delta.x;
+              rh = sv.height + delta.y;
+              break;
+            case 'bottomRight':
+              rw = sv.width + delta.x;
+              rh = sv.height + delta.y;
+              break;
+          }
+
+          const offsetFn = drag.scene.variables.getOffset(drag.propertyName);
+          const newOff = offsetFn
+            ? offsetFn({x: rx, y: ry, width: rw, height: rh})
+            : {x: 0, y: 0};
+          signal({
+            x: rx - newOff.x,
+            y: ry - newOff.y,
+            width: rw,
+            height: rh,
+          });
+        }
+
+        player.requestRender();
+      }}
+      onPointerUp={event => {
+        if (
+          !dragState.current ||
+          !event.currentTarget.hasPointerCapture(event.pointerId)
+        ) {
+          return;
+        }
+
+        event.currentTarget.releasePointerCapture(event.pointerId);
+        const drag = dragState.current;
+        dragState.current = null;
+
+        const signal = drag.scene.variables.getSignalRef(drag.propertyName);
+        if (!signal) return;
+
+        const currentValue = signal();
+        drag.scene.variables.set(drag.propertyName, currentValue);
+      }}
+    />
+  );
+}

--- a/packages/ui/src/components/viewport/PropertyInspector.tsx
+++ b/packages/ui/src/components/viewport/PropertyInspector.tsx
@@ -1,0 +1,115 @@
+import type {Scene} from '@canvas-commons/core';
+import type {EditableVariable} from '@canvas-commons/core/lib/scenes/editableVariables';
+import {useCallback} from 'preact/hooks';
+import {useApplication} from '../../contexts';
+import {useScenes, useSubscribableValue} from '../../hooks';
+import {Group, Label, PresetPicker, Separator} from '../controls';
+import {EditablePropertyField} from '../fields/EditablePropertyField';
+import {FieldSurface} from '../fields/Layout';
+import {Pane} from '../tabs/Pane';
+
+export const PROPERTY_INSPECTOR_KEY = '@canvas-commons/core/property-inspector';
+
+interface PropertyInspectorPayload {
+  sceneName: string;
+  propertyName: string;
+}
+
+function PropertyInspectorInner({
+  scene,
+  propertyName,
+}: {
+  scene: Scene;
+  propertyName: string;
+}) {
+  const {player} = useApplication();
+  const properties = useSubscribableValue(scene.variables.onChanged);
+  const property = properties?.find(
+    (p: EditableVariable) => p.name === propertyName,
+  );
+
+  const handlePreviewEnd = useCallback(() => {
+    if (!property) return;
+    const signal = scene.variables.getSignalRef(property.name);
+    if (signal) {
+      signal(property.value);
+      player.requestRender();
+    }
+  }, [property, scene, player]);
+
+  if (!property) {
+    return null;
+  }
+
+  return (
+    <Pane title="Property" id="property-inspector-pane">
+      <Separator size={1} />
+      <Group>
+        <Label>name</Label>
+        <FieldSurface>
+          <span style={{padding: '0 8px', opacity: 0.6}}>{property.name}</span>
+        </FieldSurface>
+      </Group>
+      <Group>
+        <Label>type</Label>
+        <FieldSurface>
+          <span style={{padding: '0 8px', opacity: 0.6}}>{property.type}</span>
+        </FieldSurface>
+      </Group>
+      <Separator size={1} />
+      <Group>
+        <Label>value</Label>
+        <EditablePropertyField
+          property={property}
+          onChange={value => scene.variables.set(property.name, value)}
+          onPreview={value => {
+            const signal = scene.variables.getSignalRef(property.name);
+            if (signal) {
+              signal(value);
+              player.requestRender();
+            }
+          }}
+          onPreviewEnd={handlePreviewEnd}
+        />
+      </Group>
+      {property.presets && property.presets.length > 0 && (
+        <Group>
+          <Label>presets</Label>
+          <PresetPicker
+            presets={property.presets}
+            type={property.type}
+            onSelect={value => scene.variables.set(property.name, value)}
+            onPreview={value => {
+              const signal = scene.variables.getSignalRef(property.name);
+              if (signal) {
+                signal(value);
+                player.requestRender();
+              }
+            }}
+            onPreviewEnd={handlePreviewEnd}
+          />
+        </Group>
+      )}
+    </Pane>
+  );
+}
+
+function PropertyInspectorComponent() {
+  const {inspection} = useApplication();
+  const scenes = useScenes();
+  const payload = inspection.value.payload as PropertyInspectorPayload;
+  const scene = scenes.find(s => s.name === payload?.sceneName);
+
+  if (!scene) {
+    return null;
+  }
+
+  return (
+    <PropertyInspectorInner scene={scene} propertyName={payload.propertyName} />
+  );
+}
+
+export const PropertyInspectorConfig = {
+  key: PROPERTY_INSPECTOR_KEY,
+  component: PropertyInspectorComponent,
+};

--- a/packages/ui/src/contexts/panels.tsx
+++ b/packages/ui/src/contexts/panels.tsx
@@ -1,6 +1,7 @@
 import {computed, ReadonlySignal} from '@preact/signals';
 import {ComponentChildren, createContext} from 'preact';
 import {useContext, useMemo} from 'preact/hooks';
+import {PropertyInspectorConfig} from '../components/viewport/PropertyInspector';
 import {PluginInspectorConfig, PluginTabConfig} from '../plugin';
 import {EditorPanel, storedSignal} from '../signals';
 import {useApplication} from './application';
@@ -41,7 +42,7 @@ export function PanelsProvider({children}: {children: ComponentChildren}) {
   }, [plugins]);
 
   const inspectors = useMemo(() => {
-    const inspectors: PluginInspectorConfig[] = [];
+    const inspectors: PluginInspectorConfig[] = [PropertyInspectorConfig];
     for (const plugin of plugins) {
       for (const inspector of plugin.inspectors ?? []) {
         inspectors.push(inspector);


### PR DESCRIPTION
Usage example:

```tsx
import {Layout, Rect, makeScene2D} from '@canvas-commons/2d';
import {
  BBox,
  Color,
  all,
  createRef,
  easeInExpo,
  easeInOutExpo,
  waitFor,
  waitUntil,
} from '@canvas-commons/core';

export default makeScene2D(function* (view) {
  const rect = createRef<Rect>();
  const bbox = BBox.createEditableVariable(
    'bbox',
    {x: 0, y: 0, width: 320, height: 320},
    {
      transform: () => rect().parentToWorld(),
      offset: it => ({x: -it.width / 2, y: -it.height / 2}),
    },
  );

  view.add(
    <Layout>
      <Rect
        ref={rect}
        size={() => bbox().size}
        radius={80}
        smoothCorners
        fill={'#f3303f'}
        position={() => bbox().position}
      />
    </Layout>,
  );

  yield* waitUntil('rect');
  yield* rect().scale(2, 1, easeInOutExpo).to(1, 0.6, easeInExpo);
  const color = Color.createEditableVariable('color', '#ffa56d', {
    presets: ['#f3303f', '#ffa56d', '#febb2a', '#4ecb71', '#3b82f6'],
  });
  rect().fill(color);
  yield* all(rect().ripple(1));
  yield* waitFor(0.3);
});
```

Implements [motion-canvas#170](https://github.com/motion-canvas/motion-canvas/issues/170). I opted to use the existing variable system rather than adding a new properties member to the Player and Presenter classes that at runtime does effectively the same thing.