### PR TITLE
fix(docs): fix load errors with AnimationPlayer

### DIFF
--- a/packages/examples/vite.config.ts
+++ b/packages/examples/vite.config.ts
@@ -1,4 +1,5 @@
 import canvasCommons from '@canvas-commons/vite-plugin';
+import path from 'path';
 import {defineConfig} from 'vite';
 
 export default defineConfig({
@@ -34,7 +35,8 @@ export default defineConfig({
     rollupOptions: {
       output: {
         dir: '../docs/static/examples',
-        entryFileNames: '[name].js',
+        // The docs expect .js files to be directly in examples/ rather than examples/src/.
+        entryFileNames: chunk => `${path.basename(chunk.name, '.ts')}.js`,
       },
     },
   },


### PR DESCRIPTION
Some documentation pages embed examples from the @canvas-commons/examples package with the AnimationPlayer component. This was broken with the player attempting to request e.g. /examples/transitions.js which returned a 404 since the example package was building the .js files under /examples/src. This apparently changed at some point.