### PR TITLE
fix(2d): fix cached camera child calculation

### DIFF
--- a/packages/2d/src/lib/components/Camera.ts
+++ b/packages/2d/src/lib/components/Camera.ts
@@ -15,7 +15,7 @@ import {
   unwrap,
   Vector2,
 } from '@canvas-commons/core';
-import {cloneable, signal} from '../decorators';
+import {cloneable, computed, signal} from '../decorators';
 import {Curve} from './Curve';
 import {Node, NodeProps} from './Node';
 import {Rect, RectProps} from './Rect';
@@ -90,6 +90,23 @@ export class Camera extends Node {
 
     if (children) {
       this.scene().add(children);
+    }
+
+    const scene = this.scene();
+    if (scene.parent() !== this) {
+      scene.parent(this);
+    }
+  }
+
+  protected setScene(value: SignalValue<Node>) {
+    const previous = this.scene.context.raw();
+    this.scene.context.setter(value);
+    const current = this.scene.context.raw();
+    if (previous instanceof Node && previous !== current) {
+      previous.parent(null);
+    }
+    if (current instanceof Node && current.parent() !== this) {
+      current.parent(this);
     }
   }
 
@@ -330,13 +347,38 @@ export class Camera extends Node {
     );
   }
 
+  /**
+   * Extend the `localToWorld` chain so descendants of the camera's scene
+   * end up in canvas-pixel coordinates that match where they actually
+   * render.
+   */
+  @computed()
+  public override localToWorld(): DOMMatrix {
+    const parent = this.parent();
+    const matrix = this.localToParent().inverse();
+    return parent ? parent.localToWorld().multiply(matrix) : matrix;
+  }
+
+  /**
+   * Override parentToWorld to fix gizmo drawing; may have side effects on the
+   * absolute position of the camera, but direct reads from position
+   * should be fine.
+   *
+   * If you need the absolute position of the camera, use
+   * `view.localToWorld().transformPoint(camera.position())` instead.
+   */
+  @computed()
+  public override parentToWorld(): DOMMatrix {
+    return this.localToParent();
+  }
+
   public override hit(position: Vector2): Node | null {
     const local = position.transformAsPoint(this.localToParent());
     return this.scene().hit(local);
   }
 
   protected override drawChildren(context: CanvasRenderingContext2D) {
-    (this.scene() as Camera).drawChildren(context);
+    this.scene().render(context);
   }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/2d/src/lib/components/__tests__/Camera.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/Camera.test.tsx
@@ -1,0 +1,73 @@
+import {Vector2} from '@canvas-commons/core';
+import 'geometry-polyfill';
+import {describe, expect, it} from 'vitest';
+import {useScene2D} from '../../scenes';
+import {Camera} from '../Camera';
+import {Node} from '../Node';
+import {Rect} from '../Rect';
+import {mockScene2D} from './mockScene2D';
+
+describe('Camera', () => {
+  mockScene2D();
+
+  it("parents the scene so descendants' localToWorld matches rendering", () => {
+    const view = useScene2D().getView();
+    const child = new Rect({size: 100, position: [0, 0]});
+    const camera = new Camera({children: child});
+    view.add(camera);
+
+    expect(camera.scene().parent()).toBe(camera);
+
+    const worldOrigin = new Vector2(0, 0).transformAsPoint(
+      child.localToWorld(),
+    );
+    const viewCenter = new Vector2(0, 0).transformAsPoint(view.localToWorld());
+    expect(worldOrigin.x).toBeCloseTo(viewCenter.x, 3);
+    expect(worldOrigin.y).toBeCloseTo(viewCenter.y, 3);
+  });
+
+  it('applies the inverse camera transform to descendants in world-space', () => {
+    const view = useScene2D().getView();
+    const child = new Rect({size: 100, position: [0, 0]});
+    const camera = new Camera({position: [-300, 120], children: child});
+    view.add(camera);
+
+    const viewCenter = new Vector2(0, 0).transformAsPoint(view.localToWorld());
+    const childWorld = new Vector2(0, 0).transformAsPoint(child.localToWorld());
+
+    expect(childWorld.x).toBeCloseTo(viewCenter.x + 300, 3);
+    expect(childWorld.y).toBeCloseTo(viewCenter.y - 120, 3);
+  });
+
+  it("updates descendants' localToWorld when the camera pans", () => {
+    const view = useScene2D().getView();
+    const child = new Rect({size: 100, position: [-200, 0]});
+    const camera = new Camera({children: child});
+    view.add(camera);
+
+    const viewCenter = new Vector2(0, 0).transformAsPoint(view.localToWorld());
+
+    const before = new Vector2(0, 0).transformAsPoint(child.localToWorld());
+    expect(before.x).toBeCloseTo(viewCenter.x - 200, 3);
+
+    camera.position([-400, 0]);
+
+    const after = new Vector2(0, 0).transformAsPoint(child.localToWorld());
+    expect(after.x).toBeCloseTo(viewCenter.x + 200, 3);
+  });
+
+  it('reparents the scene when reassigning the scene signal', () => {
+    const view = useScene2D().getView();
+    const camera = new Camera({});
+    view.add(camera);
+
+    const originalScene = camera.scene();
+    expect(originalScene.parent()).toBe(camera);
+
+    const newScene = new Node({});
+    camera.scene(newScene);
+
+    expect(newScene.parent()).toBe(camera);
+    expect(originalScene.parent()).toBe(null);
+  });
+});

--- a/packages/2d/src/lib/scenes/Scene2D.ts
+++ b/packages/2d/src/lib/scenes/Scene2D.ts
@@ -10,8 +10,7 @@ import {
   Vector2,
   useLogger,
 } from '@canvas-commons/core';
-import {Camera, Node, View2D} from '../components';
-import {is} from '../utils';
+import {Node, View2D} from '../components';
 
 export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
   private view: View2D | null = null;
@@ -112,34 +111,7 @@ export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
     const node = this.getNode(element);
     if (node) {
       this.execute(() => {
-        const cameras = this.getView().findAll(is(Camera));
-        const parentCameras = [];
-        for (const camera of cameras) {
-          const scene = camera.scene();
-          if (!scene) continue;
-
-          if (scene === node || scene.findFirst(n => n === node)) {
-            parentCameras.push(camera);
-          }
-        }
-
-        if (parentCameras.length > 0) {
-          for (const camera of parentCameras) {
-            const cameraParentToWorld = camera.parentToWorld();
-            const cameraLocalToParent = camera.localToParent().inverse();
-            const nodeLocalToWorld = node.localToWorld();
-
-            node.drawOverlay(
-              context,
-              matrix
-                .multiply(cameraParentToWorld)
-                .multiply(cameraLocalToParent)
-                .multiply(nodeLocalToWorld),
-            );
-          }
-        } else {
-          node.drawOverlay(context, matrix.multiply(node.localToWorld()));
-        }
+        node.drawOverlay(context, matrix.multiply(node.localToWorld()));
       });
     }
   }


### PR DESCRIPTION
Fixes #19 and [this upstream issue](https://github.com/motion-canvas/motion-canvas/issues/1057).