### PR TITLE
feat(editor): add copy and download canvas shortcuts

### DIFF
--- a/.changeset/copy-canvas-shortcuts.md
+++ b/.changeset/copy-canvas-shortcuts.md
@@ -1,0 +1,6 @@
+---
+'@canvas-commons/editor': minor
+---
+
+add `Shift + C` / `Shift + D` viewport shortcuts to copy the current frame to
+the clipboard or download it as a PNG.

--- a/packages/editor/src/components/viewport/PreviewStage.tsx
+++ b/packages/editor/src/components/viewport/PreviewStage.tsx
@@ -2,6 +2,7 @@ import {Stage} from '@canvas-commons/core';
 import {JSX} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 import {useApplication} from '../../contexts';
+import {VIEWPORT_SHORTCUTS, useShortcuts} from '../../contexts/shortcuts';
 import {
   usePreviewSettings,
   useSharedSettings,
@@ -11,7 +12,7 @@ import {StageView} from './StageView';
 
 export function PreviewStage(props: JSX.HTMLAttributes<HTMLDivElement>) {
   const [stage] = useState(() => new Stage());
-  const {player} = useApplication();
+  const {player, project} = useApplication();
   const {size, background} = useSharedSettings();
   const {resolutionScale} = usePreviewSettings();
 
@@ -31,5 +32,36 @@ export function PreviewStage(props: JSX.HTMLAttributes<HTMLDivElement>) {
     player.requestRender();
   }, [resolutionScale, size, background, player]);
 
+  useShortcuts(VIEWPORT_SHORTCUTS, {
+    copyFrame: async () => {
+      const blob = await canvasToPng(stage.finalBuffer);
+      if (!blob) return;
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      await navigator.clipboard.write([new ClipboardItem({'image/png': blob})]);
+    },
+    downloadFrame: async () => {
+      const blob = await canvasToPng(stage.finalBuffer);
+      if (!blob) return;
+      const scene = player.playback.currentScene;
+      const sceneFrame = player.playback.frame - scene.firstFrame;
+      downloadBlob(blob, `${project.name}-${scene.name}-${sceneFrame}.png`);
+    },
+  });
+
   return <StageView stage={stage} {...props} />;
+}
+
+function canvasToPng(canvas: HTMLCanvasElement): Promise<Blob | null> {
+  return new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
 }

--- a/packages/editor/src/contexts/shortcuts.tsx
+++ b/packages/editor/src/contexts/shortcuts.tsx
@@ -98,6 +98,18 @@ export const VIEWPORT_SHORTCUTS = makeShortcuts('viewport', {
     key: 'p',
     modifiers: {},
   },
+  copyFrame: {
+    display: 'Shift + C',
+    description: 'Copy frame to clipboard',
+    key: 'C',
+    modifiers: {shift: true},
+  },
+  downloadFrame: {
+    display: 'Shift + D',
+    description: 'Download frame as PNG',
+    key: 'D',
+    modifiers: {shift: true},
+  },
   ...(typeof EyeDropper !== 'undefined'
     ? {
         colorPicker: {


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create one first).
- [x] **Mandatory**: The issue has been accepted (indicated by a [`c-accepted`][label-accepted] label) and is assigned to me.
- [x] **Mandatory**: I have read and understood the [AI policy][ai-policy].
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. I have added an `Assisted-by: <tool name / model>` trailer to the commit message.
      
[ai-policy]: https://github.com/canvas-commons/.github/blob/main/AI_POLICY.md
[label-accepted]: https://github.com/canvas-commons/canvas-commons/issues?q=state%3Aopen%20label%3Ac-accepted

If a checkbox is not applicable, you can leave it unchecked.

## Summary

Adds copy and download current frame shortcuts to the editor

## Test Plan

Both shortcuts work; verified locally.