### PR TITLE
ci: add docker e2e emulator

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"bc9f9e27-1b15-4592-913b-464db0330dca","pid":42392,"acquiredAt":1779169182041}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+**/node_modules
+.pnpm-store
+packages/*/dist
+packages/*/lib
+packages/*/.cache
+packages/*/.turbo
+packages/2d/editor
+packages/e2e/output
+packages/e2e/src/__image_snapshots__/__diff_output__
+.git
+.github
+.claude
+.husky
+.idea
+.vscode
+*.log

--- a/packages/e2e/AGENTS.md
+++ b/packages/e2e/AGENTS.md
@@ -38,6 +38,24 @@ pnpm --filter @canvas-commons/e2e test -t "quickstart > frame peak"
 Always rerun the full suite before committing snapshot changes — filtered runs
 won't catch knock-on regressions in other scenes.
 
+### Regenerating snapshots for CI
+
+Canvas rendering is not pixel-identical across operating systems — fonts, GPU
+drivers, and color profiles all leak through. Snapshots committed from a Windows
+or macOS dev machine will diff against the CI Linux+Firefox run.
+
+To keep CI green, regenerate baselines inside the same container CI uses:
+
+```bash
+pnpm --filter @canvas-commons/e2e run test:docker
+```
+
+This builds a local image from `packages/e2e/Dockerfile.test` (Playwright's
+Jammy image with Node 22 layered on, matching `.github/workflows/verify.yml`)
+and runs `pnpm run e2e:test` inside it.
+
+Requires Docker. First build pulls the Playwright image (~1.5 GB).
+
 ## Traps
 
 **Image snapshots are checked into git.** If your change alters rendered output,

--- a/packages/e2e/Dockerfile.test
+++ b/packages/e2e/Dockerfile.test
@@ -1,0 +1,39 @@
+# Mirrors the CI E2E container: Playwright's official image (jammy) with
+# Node 22 layered on top via NodeSource — same pattern verify.yml uses.
+# Build context is the repo root. Build with:
+#
+#   docker build --build-arg PLAYWRIGHT_VERSION=<resolved> \
+#     -f packages/e2e/Dockerfile.test -t <tag> .
+ARG PLAYWRIGHT_VERSION
+FROM mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-jammy
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/* && \
+    corepack enable
+
+WORKDIR /work
+
+# Manifests only — invalidating any of these reruns `pnpm install`.
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/2d/package.json ./packages/2d/
+COPY packages/core/package.json ./packages/core/
+COPY packages/create/package.json ./packages/create/
+COPY packages/docs/package.json ./packages/docs/
+COPY packages/e2e/package.json ./packages/e2e/
+COPY packages/editor/package.json ./packages/editor/
+COPY packages/examples/package.json ./packages/examples/
+COPY packages/ffmpeg/package.json ./packages/ffmpeg/
+COPY packages/player/package.json ./packages/player/
+COPY packages/template/package.json ./packages/template/
+COPY packages/vite-plugin/package.json ./packages/vite-plugin/
+
+RUN pnpm install --frozen-lockfile
+
+# Source. Code changes land here and invalidate only the build + test layers
+# that follow.
+COPY . .
+
+RUN pnpm run build
+
+CMD ["pnpm", "run", "e2e:test"]

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:docker": "node scripts/test-docker.mjs"
   },
   "dependencies": {
     "@canvas-commons/2d": "workspace:^",

--- a/packages/e2e/scripts/test-docker.mjs
+++ b/packages/e2e/scripts/test-docker.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import {spawnSync} from 'node:child_process';
+import {readFileSync} from 'node:fs';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const e2eDir = resolve(here, '..');
+const repoRoot = resolve(e2eDir, '../..');
+
+// CI resolves the playwright tag from the lockfile
+// (atos-actions/get-playwright-version). Mirror that so the container's
+// browsers match what pnpm will actually install.
+const lockfile = readFileSync(resolve(repoRoot, 'pnpm-lock.yaml'), 'utf8');
+const match = lockfile.match(/^ {2}playwright@(\d+\.\d+\.\d+):$/m);
+const playwrightVersion = match?.[1];
+if (!playwrightVersion) {
+  console.error('Could not resolve playwright version from pnpm-lock.yaml');
+  process.exit(1);
+}
+
+const tag = `canvas-commons-e2e:pw-${playwrightVersion}`;
+const snapshotsDir = resolve(e2eDir, 'src', '__image_snapshots__');
+
+console.log(`Building ${tag} (repo root as context)...`);
+const build = spawnSync(
+  'docker',
+  [
+    'build',
+    '--build-arg',
+    `PLAYWRIGHT_VERSION=${playwrightVersion}`,
+    '-f',
+    resolve(e2eDir, 'Dockerfile.test'),
+    '-t',
+    tag,
+    repoRoot,
+  ],
+  {stdio: 'inherit'},
+);
+if (build.status !== 0) process.exit(build.status ?? 1);
+
+const userCommand = process.argv.slice(2).join(' ');
+
+console.log(
+  userCommand ? `Running: ${userCommand}` : 'Running: pnpm run e2e:test',
+);
+// Mount only the snapshots dir out so regenerated baselines land in the
+// host worktree. Everything else (node_modules, source, build output)
+// stays inside the container — the host's install never gets touched.
+const args = [
+  'run',
+  '--rm',
+  '-v',
+  `${snapshotsDir}:/work/packages/e2e/src/__image_snapshots__`,
+  tag,
+];
+if (userCommand) args.push('bash', '-c', userCommand);
+const run = spawnSync('docker', args, {stdio: 'inherit'});
+process.exit(run.status ?? 1);


### PR DESCRIPTION
## Pre-submission checks

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create one first).
- [ ] **Mandatory**: The issue has been accepted (indicated by a [`c-accepted`][label-accepted] label) and is assigned to me.
- [x] **Mandatory**: I have read and understood the [AI policy][ai-policy].
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. I have added an `Assisted-by: <tool name / model>` trailer to the commit message.

## Summary

Adds a docker script to render in the same environment as CI.

## Test Plan

Passes locally.

[ai-policy]: https://github.com/canvas-commons/.github/blob/main/AI_POLICY.md
[label-accepted]: https://github.com/canvas-commons/canvas-commons/issues?q=state%3Aopen%20label%3Ac-accepted
