### PR TITLE
fix(core): make signals inherit property metadata and initializers

### DIFF
--- a/.changeset/signal-inherited-property-metadata.md
+++ b/.changeset/signal-inherited-property-metadata.md
@@ -1,0 +1,8 @@
+---
+'@canvas-commons/2d': patch
+---
+
+Resolve property metadata and initializers through the prototype chain, so
+contributions to a base class apply to its subclasses even when registered late.
+Override decorators like `@initial` on a subclass now require redeclaring
+`@signal()` there instead of mutating the base class's metadata.

--- a/packages/2d/src/lib/decorators/initializers.ts
+++ b/packages/2d/src/lib/decorators/initializers.ts
@@ -2,31 +2,62 @@ const INITIALIZERS = Symbol.for('@canvas-commons/2d/decorators/initializers');
 
 export type Initializer<T> = (instance: T, context?: any) => void;
 
-export function addInitializer<T>(target: any, initializer: Initializer<T>) {
-  if (!target[INITIALIZERS]) {
-    target[INITIALIZERS] = [];
-  } else if (
-    // if one of the prototypes has initializers
-    target[INITIALIZERS] &&
-    // and it's not the target object itself
-    !Object.prototype.hasOwnProperty.call(target, INITIALIZERS)
-  ) {
-    const base = Object.getPrototypeOf(target);
-    target[INITIALIZERS] = [...base[INITIALIZERS]];
-  }
+export type Constructor = new (...args: any[]) => any;
 
+let InitializerEpoch = 0;
+
+const InitializerChainCache = new WeakMap<
+  Constructor,
+  {epoch: number; initializers: Initializer<any>[]}
+>();
+
+export function addInitializer<T>(target: any, initializer: Initializer<T>) {
+  if (!Object.prototype.hasOwnProperty.call(target, INITIALIZERS)) {
+    target[INITIALIZERS] = [];
+  }
   target[INITIALIZERS].push(initializer);
+  InitializerEpoch++;
 }
 
-export function initialize(target: any, context?: any) {
-  if (target[INITIALIZERS]) {
-    try {
-      target[INITIALIZERS].forEach((initializer: Initializer<any>) =>
-        initializer(target, context),
-      );
-    } catch (e: any) {
-      e.inspect ??= target.key;
-      throw e;
+function getInitializersOf(ctor: any): Initializer<any>[] {
+  if (typeof ctor !== 'function') {
+    return [];
+  }
+
+  const cached = InitializerChainCache.get(ctor);
+  if (cached && cached.epoch === InitializerEpoch) {
+    return cached.initializers;
+  }
+
+  const chain: any[] = [];
+  let prototype = ctor.prototype;
+  while (prototype && prototype !== Object.prototype) {
+    chain.push(prototype);
+    prototype = Object.getPrototypeOf(prototype);
+  }
+
+  const initializers: Initializer<any>[] = [];
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const prototype = chain[i];
+    if (Object.prototype.hasOwnProperty.call(prototype, INITIALIZERS)) {
+      initializers.push(...prototype[INITIALIZERS]);
     }
+  }
+
+  InitializerChainCache.set(ctor, {epoch: InitializerEpoch, initializers});
+  return initializers;
+}
+
+export function initialize(instance: any, context?: any) {
+  const initializers = getInitializersOf(instance.constructor);
+  if (initializers.length === 0) {
+    return;
+  }
+
+  try {
+    initializers.forEach(initializer => initializer(instance, context));
+  } catch (e: any) {
+    e.inspect ??= instance.key;
+    throw e;
   }
 }

--- a/packages/2d/src/lib/decorators/signal.test.ts
+++ b/packages/2d/src/lib/decorators/signal.test.ts
@@ -1,6 +1,16 @@
-import {DEFAULT, SimpleSignal} from '@canvas-commons/core';
+import {CompoundSignal, DEFAULT, SimpleSignal} from '@canvas-commons/core';
 import {beforeEach, describe, expect, test, vi} from 'vitest';
-import {initial, initializeSignals, parser, signal} from './signal';
+import {compound} from './compound';
+import {computed} from './computed';
+import {
+  getPropertiesOf,
+  getPropertyMetaOrCreate,
+  initial,
+  initializeSignals,
+  interpolation,
+  parser,
+  signal,
+} from './signal';
 
 interface OwnerProps {
   integer?: number;
@@ -85,5 +95,216 @@ describe('signal', () => {
     instance.custom(2);
 
     expect(SetterMock).toBeCalledTimes(3);
+  });
+});
+
+describe('property metadata chain-walk', () => {
+  class Base {
+    @initial(1)
+    @signal()
+    declare public readonly length: SimpleSignal<number>;
+
+    public constructor(props: {length?: number} = {}) {
+      initializeSignals(this, props);
+    }
+  }
+
+  class Derived extends Base {}
+
+  test('a property declared on a base class is visible on a subclass', () => {
+    const instance = new Derived();
+
+    expect(instance.length()).toBe(1);
+  });
+
+  test('a property registered on a base class after a subclass is declared becomes usable on that subclass', () => {
+    class LateBase {
+      @initial(2)
+      @signal()
+      declare public readonly width: SimpleSignal<number>;
+
+      public constructor(props: {width?: number} = {}) {
+        initializeSignals(this, props);
+      }
+    }
+
+    class LateDerived extends LateBase {}
+
+    // Warm the subclass caches before the base gains the property.
+    expect(Object.keys(getPropertiesOf(LateDerived))).toEqual(['width']);
+    expect(new LateDerived({width: 5}).width()).toBe(5);
+
+    signal<number>()(LateBase.prototype, 'height');
+    initial(3)(LateBase.prototype, 'height');
+
+    expect(Object.keys(getPropertiesOf(LateDerived))).toEqual([
+      'width',
+      'height',
+    ]);
+
+    const instance = new LateDerived({width: 5}) as LateDerived & {
+      height: SimpleSignal<number>;
+    };
+    expect(instance.height()).toBe(3);
+    instance.height(7);
+    expect(instance.height()).toBe(7);
+  });
+
+  test('a subclass can decorate a property for the same key differently than its base', () => {
+    class Wrapper {
+      @initial(1)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor(props: {value?: number} = {}) {
+        initializeSignals(this, props);
+      }
+    }
+
+    class Overridden extends Wrapper {
+      @initial(1)
+      @interpolation((from: number, to: number, t: number) => from + to + t)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor(props: {value?: number} = {}) {
+        super(props);
+      }
+    }
+
+    const properties = getPropertiesOf(Overridden);
+    expect(properties.value.interpolationFunction!(1, 2, 3)).toBe(6);
+  });
+
+  test('a compound signal declared on a base class resolves on a subclass', () => {
+    class CompoundOwner {
+      @initial({x: 0, y: 0})
+      @parser((value: {x: number; y: number}) => value)
+      @compound({x: 'scaleX', y: 'scaleY'})
+      declare public readonly scale: CompoundSignal<
+        {x: number; y: number},
+        {x: number; y: number}
+      >;
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    class CompoundDerived extends CompoundOwner {}
+
+    const properties = getPropertiesOf(CompoundDerived);
+    expect(properties.scale.compound).toBe(true);
+    expect(properties.scale.compoundEntries).toEqual([
+      ['x', 'scaleX'],
+      ['y', 'scaleY'],
+    ]);
+
+    const instance = new CompoundDerived();
+    expect(instance.scale.x()).toBe(0);
+    instance.scale({x: 3, y: 4});
+    expect(instance.scale.x()).toBe(3);
+    expect(instance.scale.y()).toBe(4);
+  });
+
+  test('a computed method registered on a base class after a subclass is cached runs on that subclass', () => {
+    class ComputedBase {
+      @computed()
+      public label() {
+        return 'base';
+      }
+
+      public extra() {
+        return 'late';
+      }
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    class ComputedDerived extends ComputedBase {}
+
+    // Warm the subclass caches before the base gains the computed method.
+    expect(new ComputedDerived().label()).toBe('base');
+
+    const descriptor = Object.getOwnPropertyDescriptor(
+      ComputedBase.prototype,
+      'extra',
+    );
+    if (!descriptor) {
+      throw new Error('expected "extra" to be declared on ComputedBase');
+    }
+    computed()(ComputedBase.prototype, 'extra', descriptor);
+
+    const instance = new ComputedDerived();
+    expect(instance.label()).toBe('base');
+    expect(instance.extra()).toBe('late');
+  });
+
+  test('getDefault* resolves through a prototype patched after the class declares its signal', () => {
+    class Owner {
+      @signal()
+      declare public readonly amount: SimpleSignal<number>;
+
+      public constructor(props: {amount?: number} = {}) {
+        initializeSignals(this, props);
+      }
+    }
+
+    Object.assign(Owner.prototype, {getDefaultAmount: () => 42});
+
+    const instance = new Owner();
+    expect(instance.amount()).toBe(42);
+  });
+
+  test('resolution is cached per constructor and only recomputed after metadata changes', () => {
+    class Cached extends Base {}
+
+    const first = getPropertiesOf(Cached);
+    const second = getPropertiesOf(Cached);
+    expect(second).toBe(first);
+
+    getPropertyMetaOrCreate<number>(Cached.prototype, 'extraCached').default =
+      5;
+
+    const third = getPropertiesOf(Cached);
+    expect(third).not.toBe(first);
+    expect(third.extraCached.default).toBe(5);
+  });
+
+  test('constructing a thousand instances stays cheap once the chain is cached', () => {
+    class Benchmarked extends Base {
+      @initial(0)
+      @signal()
+      declare public readonly a: SimpleSignal<number>;
+      @initial(0)
+      @signal()
+      declare public readonly b: SimpleSignal<number>;
+      @initial(0)
+      @signal()
+      declare public readonly c: SimpleSignal<number>;
+
+      public constructor(props: {length?: number} = {}) {
+        super(props);
+      }
+    }
+
+    // Warm the per-constructor cache.
+    new Benchmarked();
+
+    const propertiesBefore = getPropertiesOf(Benchmarked);
+
+    // Counting chain walks instead of timing keeps this machine-independent.
+    const getPrototypeOfSpy = vi.spyOn(Object, 'getPrototypeOf');
+    for (let i = 0; i < 1000; i++) {
+      new Benchmarked();
+    }
+    const chainWalkCallsPerInstance =
+      getPrototypeOfSpy.mock.calls.length / 1000;
+    getPrototypeOfSpy.mockRestore();
+
+    expect(getPropertiesOf(Benchmarked)).toBe(propertiesBefore);
+    expect(chainWalkCallsPerInstance).toBeLessThan(1);
   });
 });

--- a/packages/2d/src/lib/decorators/signal.ts
+++ b/packages/2d/src/lib/decorators/signal.ts
@@ -8,7 +8,7 @@ import {
   useLogger,
 } from '@canvas-commons/core';
 import {makeSignalExtensions} from '../utils/makeSignalExtensions';
-import {addInitializer, initialize} from './initializers';
+import {addInitializer, Constructor, initialize} from './initializers';
 
 export interface PropertyMetadata<T> {
   default?: T;
@@ -31,49 +31,77 @@ export interface PropertyMetadata<T> {
 
 const PROPERTIES = Symbol.for('@canvas-commons/2d/decorators/properties');
 
+let PropertyMetaEpoch = 0;
+
+export function invalidatePropertyMetaCache() {
+  PropertyMetaEpoch++;
+}
+
+const PropertyChainCache = new WeakMap<
+  Constructor,
+  {epoch: number; properties: Record<string, PropertyMetadata<any>>}
+>();
+
 export function getPropertyMeta<T>(
-  object: any,
+  target: any,
   key: string | symbol,
 ): PropertyMetadata<T> | null {
-  return object[PROPERTIES]?.[key] ?? null;
+  if (!Object.prototype.hasOwnProperty.call(target, PROPERTIES)) {
+    return null;
+  }
+  return target[PROPERTIES][key] ?? null;
 }
 
 export function getPropertyMetaOrCreate<T>(
-  object: any,
+  target: any,
   key: string | symbol,
 ): PropertyMetadata<T> {
-  let lookup: Record<string | symbol, PropertyMetadata<T>>;
-  if (!object[PROPERTIES]) {
-    object[PROPERTIES] = lookup = {};
-  } else if (
-    object[PROPERTIES] &&
-    !Object.prototype.hasOwnProperty.call(object, PROPERTIES)
-  ) {
-    object[PROPERTIES] = lookup = Object.fromEntries<PropertyMetadata<T>>(
-      Object.entries(
-        <Record<string | symbol, PropertyMetadata<T>>>object[PROPERTIES],
-      ).map(([key, meta]) => [key, {...meta}]),
-    );
-  } else {
-    lookup = object[PROPERTIES];
+  if (!Object.prototype.hasOwnProperty.call(target, PROPERTIES)) {
+    target[PROPERTIES] = {};
   }
+  const lookup: Record<string | symbol, PropertyMetadata<T>> = target[
+    PROPERTIES
+  ];
 
   lookup[key] ??= {
     cloneable: true,
     inspectable: true,
     compoundEntries: [],
   };
+  invalidatePropertyMetaCache();
   return lookup[key];
 }
 
 export function getPropertiesOf(
   value: any,
 ): Record<string, PropertyMetadata<any>> {
-  if (value && typeof value === 'object') {
-    return value[PROPERTIES] ?? {};
+  const ctor = typeof value === 'function' ? value : value?.constructor;
+  if (typeof ctor !== 'function') {
+    return {};
   }
 
-  return {};
+  const cached = PropertyChainCache.get(ctor);
+  if (cached && cached.epoch === PropertyMetaEpoch) {
+    return cached.properties;
+  }
+
+  const chain: any[] = [];
+  let prototype = ctor.prototype;
+  while (prototype && prototype !== Object.prototype) {
+    chain.push(prototype);
+    prototype = Object.getPrototypeOf(prototype);
+  }
+
+  const properties: Record<string, PropertyMetadata<any>> = {};
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const prototype = chain[i];
+    if (Object.prototype.hasOwnProperty.call(prototype, PROPERTIES)) {
+      Object.assign(properties, prototype[PROPERTIES]);
+    }
+  }
+
+  PropertyChainCache.set(ctor, {epoch: PropertyMetaEpoch, properties});
+  return properties;
 }
 
 export function initializeSignals(instance: any, props: Record<string, any>) {
@@ -115,9 +143,6 @@ export function initializeSignals(instance: any, props: Record<string, any>) {
  */
 export function signal<T>(): PropertyDecorator {
   return (target: any, key) => {
-    // FIXME property metadata is not inherited
-    // Consider retrieving it inside the initializer using the instance and not
-    // the class.
     const meta = getPropertyMetaOrCreate<T>(target, key);
     addInitializer(target, (instance: any) => {
       let initial: SignalValue<T> = meta.default!;


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

<!--
Please check these boxes. If a checkbox is not applicable, you can leave it unchecked.
-->

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create one first).
- [x] **Mandatory**: The issue has been accepted (indicated by a [`c-accepted`][label-accepted] label) and is assigned to me.
- [x] **Mandatory**: I have read and understood the [AI policy][ai-policy].
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. I have added an `Assisted-by: <tool name / model>` trailer to the commit message.

## Summary

Makes signal metadata and initializers inherited properly on the prototype chain.

Closes #134.

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

[ai-policy]: https://github.com/canvas-commons/.github/blob/main/AI_POLICY.md
[label-accepted]: https://github.com/canvas-commons/canvas-commons/issues?q=state%3Aopen%20label%3Ac-accepted
