### PR TITLE
feat(core): signal extend, interpolator registry, factory descriptors

### DIFF
--- a/.changeset/interpolator-registry.md
+++ b/.changeset/interpolator-registry.md
@@ -1,0 +1,8 @@
+---
+'@canvas-commons/core': minor
+---
+
+Add `SignalContext.extend` for swapping a signal's getter, setter, or tweener
+after construction. Add the `interpolators` registry: named interpolators back
+default tweens before `deepLerp`, and registered factories like
+`Vector2.createPolarLerp` produce functions carrying `{id, params}` descriptors.

--- a/packages/core/src/signals/SignalContext.test.ts
+++ b/packages/core/src/signals/SignalContext.test.ts
@@ -1,0 +1,141 @@
+import {afterAll, beforeAll, describe, expect, test, vi} from 'vitest';
+import {PlaybackManager, PlaybackStatus} from '../app';
+import {ThreadGenerator, threads} from '../threading';
+import {interpolators, map} from '../tweening';
+import {endPlayback, startPlayback} from '../utils';
+import {createSignal} from './createSignal';
+
+interface Fraction {
+  numerator: number;
+  denominator: number;
+}
+
+function isFraction(value: unknown): value is Fraction {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'numerator' in value &&
+    'denominator' in value
+  );
+}
+
+function fractionLerp(from: Fraction, to: Fraction, value: number): Fraction {
+  return {
+    numerator: map(from.numerator, to.numerator, value),
+    denominator: map(from.denominator, to.denominator, value),
+  };
+}
+
+describe('SignalContext', () => {
+  const playback = new PlaybackManager();
+  const status = new PlaybackStatus(playback);
+  beforeAll(() => startPlayback(status));
+  afterAll(() => endPlayback(status));
+
+  function run(task: Generator) {
+    playback.fps = 10;
+    playback.frame = 0;
+    while (!task.next().done) {
+      playback.frame++;
+    }
+  }
+
+  describe('extend()', () => {
+    test('Replaces the getter', () => {
+      const signal = createSignal(1);
+      const result = signal.context.extend({
+        getter: () => signal.context.getter() * 2,
+      });
+
+      expect(signal()).toBe(2);
+      expect(result).toBe(signal.context);
+    });
+
+    test('Replaces the setter', () => {
+      const signal = createSignal(0);
+      signal.context.extend({
+        setter: value =>
+          signal.context.setter(
+            typeof value === 'number' ? Math.min(value, 10) : value,
+          ),
+      });
+
+      signal(5);
+      expect(signal()).toBe(5);
+
+      signal(15);
+      expect(signal()).toBe(10);
+    });
+
+    test('Replaces the tweener', () => {
+      const signal = createSignal(0);
+      const tweener = vi.fn(function* (): ThreadGenerator {
+        return;
+      });
+      signal.context.extend({tweener});
+
+      run(
+        threads(function* () {
+          yield* signal(10, 1);
+        }),
+      );
+
+      expect(tweener).toHaveBeenCalledOnce();
+      expect(signal()).toBe(10);
+    });
+  });
+
+  describe('interpolator registry', () => {
+    test('Default tweens consult the registry', () => {
+      const lerp = vi.fn(fractionLerp);
+      const uninstall = interpolators.register({
+        name: 'test/fraction',
+        test: (a, b) => isFraction(a) && isFraction(b),
+        lerp,
+      });
+
+      try {
+        const signal = createSignal<Fraction>({numerator: 0, denominator: 2});
+        run(
+          threads(function* () {
+            yield* signal({numerator: 10, denominator: 4}, 1);
+          }),
+        );
+
+        expect(lerp).toHaveBeenCalled();
+        expect(signal()).toEqual({numerator: 10, denominator: 4});
+      } finally {
+        uninstall();
+      }
+    });
+
+    test('Explicit interpolation functions take precedence', () => {
+      const registered = vi.fn(fractionLerp);
+      const explicit = vi.fn(fractionLerp);
+      const uninstall = interpolators.register({
+        name: 'test/fraction',
+        test: (a, b) => isFraction(a) && isFraction(b),
+        lerp: registered,
+      });
+
+      try {
+        const signal = createSignal<Fraction>({numerator: 0, denominator: 2});
+        run(
+          threads(function* () {
+            yield* signal(
+              {numerator: 10, denominator: 4},
+              1,
+              undefined,
+              explicit,
+            );
+          }),
+        );
+
+        expect(explicit).toHaveBeenCalled();
+        expect(registered).not.toHaveBeenCalled();
+      } finally {
+        uninstall();
+      }
+    });
+  });
+});

--- a/packages/core/src/signals/SignalContext.ts
+++ b/packages/core/src/signals/SignalContext.ts
@@ -3,7 +3,9 @@ import {ThreadGenerator} from '../threading';
 import {
   InterpolationFunction,
   TimingFunction,
+  deepLerp,
   easeInOutCubic,
+  interpolators,
   tween,
 } from '../tweening';
 import {errorToLog, useLogger} from '../utils';
@@ -101,6 +103,27 @@ export class SignalContext<
 
   public toSignal(): Signal<TSetterValue, TValue, TOwner> {
     return this.invokable;
+  }
+
+  /**
+   * Swap out the getter, setter, or tweener of this signal.
+   *
+   * @example
+   * ```ts
+   * const signal = createSignal(1);
+   * signal.context.extend({
+   *   getter: () => signal.context.getter() * 2,
+   * });
+   * // signal() == 2
+   * ```
+   *
+   * @param partial - The extensions to apply on top of the current ones.
+   */
+  public extend(
+    partial: Partial<SignalExtensions<TSetterValue, TValue>>,
+  ): this {
+    this.extensions = {...this.extensions, ...partial};
+    return this;
   }
 
   public parse(value: TSetterValue): TValue {
@@ -269,6 +292,11 @@ export class SignalContext<
     interpolationFunction: InterpolationFunction<TValue>,
   ): ThreadGenerator {
     const from = this.get();
+    if (interpolationFunction === deepLerp) {
+      interpolationFunction =
+        interpolators.find<TValue>(from, this.parse(unwrap(value))) ??
+        interpolationFunction;
+    }
     yield* tween(duration, v => {
       this.set(
         interpolationFunction(

--- a/packages/core/src/tweening/index.ts
+++ b/packages/core/src/tweening/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from './interpolationFunctions';
+export * from './interpolators';
 export * from './spring';
 export * from './timingFunctions';
 export * from './tween';

--- a/packages/core/src/tweening/interpolators.test.ts
+++ b/packages/core/src/tweening/interpolators.test.ts
@@ -1,0 +1,254 @@
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {Vector2} from '../types';
+import {map} from './interpolationFunctions';
+import {InterpolatorEntry, interpolators} from './interpolators';
+
+interface Fraction {
+  numerator: number;
+  denominator: number;
+}
+
+function isFraction(value: unknown): value is Fraction {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'numerator' in value &&
+    'denominator' in value
+  );
+}
+
+function fractionLerp(from: Fraction, to: Fraction, value: number): Fraction {
+  return {
+    numerator: map(from.numerator, to.numerator, value),
+    denominator: map(from.denominator, to.denominator, value),
+  };
+}
+
+function testFraction(a: unknown, b: unknown) {
+  return isFraction(a) && isFraction(b);
+}
+
+describe('interpolators', () => {
+  const uninstalls: (() => void)[] = [];
+  function register<T>(entry: InterpolatorEntry<T>) {
+    const uninstall = interpolators.register(entry);
+    uninstalls.push(uninstall);
+    return uninstall;
+  }
+
+  afterEach(() => {
+    while (uninstalls.length > 0) {
+      uninstalls.pop()?.();
+    }
+  });
+
+  test('Finds a matching interpolator', () => {
+    register({name: 'test/fraction', test: testFraction, lerp: fractionLerp});
+
+    const from: Fraction = {numerator: 0, denominator: 2};
+    const to: Fraction = {numerator: 10, denominator: 4};
+    const lerp = interpolators.find<Fraction>(from, to);
+
+    expect(lerp).not.toBeNull();
+    expect(lerp?.(from, to, 0.5)).toEqual({numerator: 5, denominator: 3});
+    expect(interpolators.find(1, 2)).toBeNull();
+  });
+
+  test('Higher priority wins', () => {
+    const low = vi.fn(fractionLerp);
+    const high = vi.fn(fractionLerp);
+    register({name: 'test/low', test: testFraction, lerp: low});
+    register({name: 'test/high', test: testFraction, lerp: high, priority: 1});
+
+    const from: Fraction = {numerator: 0, denominator: 2};
+    interpolators.find<Fraction>(from, from)?.(from, from, 0.5);
+
+    expect(high).toHaveBeenCalled();
+    expect(low).not.toHaveBeenCalled();
+  });
+
+  test('Ties are broken by registration order', () => {
+    const first = vi.fn(fractionLerp);
+    const second = vi.fn(fractionLerp);
+    register({name: 'test/first', test: testFraction, lerp: first});
+    register({name: 'test/second', test: testFraction, lerp: second});
+
+    const from: Fraction = {numerator: 0, denominator: 2};
+    interpolators.find<Fraction>(from, from)?.(from, from, 0.5);
+
+    expect(first).toHaveBeenCalled();
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  test('Registering a different entry under an existing name throws', () => {
+    register({name: 'test/fraction', test: testFraction, lerp: fractionLerp});
+
+    expect(() =>
+      interpolators.register({
+        name: 'test/fraction',
+        test: testFraction,
+        lerp: (from: Fraction) => from,
+      }),
+    ).toThrow('interpolators.register("test/fraction")');
+  });
+
+  test('An identical entry stays registered until every registration uninstalls', () => {
+    const first = register({
+      name: 'test/fraction',
+      test: testFraction,
+      lerp: fractionLerp,
+    });
+    const second = register({
+      name: 'test/fraction',
+      test: testFraction,
+      lerp: fractionLerp,
+    });
+
+    first();
+    expect(interpolators.get('test/fraction')).not.toBeNull();
+
+    second();
+    expect(interpolators.get('test/fraction')).toBeNull();
+  });
+
+  test('Calling the same uninstall twice releases only one registration', () => {
+    const first = register({
+      name: 'test/fraction',
+      test: testFraction,
+      lerp: fractionLerp,
+    });
+    register({name: 'test/fraction', test: testFraction, lerp: fractionLerp});
+
+    first();
+    first();
+
+    expect(interpolators.get('test/fraction')).not.toBeNull();
+  });
+
+  test('Uninstalling removes the entry', () => {
+    const uninstall = register({
+      name: 'test/fraction',
+      test: testFraction,
+      lerp: fractionLerp,
+    });
+
+    const from: Fraction = {numerator: 0, denominator: 2};
+    expect(interpolators.find(from, from)).not.toBeNull();
+
+    uninstall();
+
+    expect(interpolators.find(from, from)).toBeNull();
+    expect(interpolators.get('test/fraction')).toBeNull();
+  });
+
+  test('Retrieves entries by name', () => {
+    const entry = {
+      name: 'test/fraction',
+      test: testFraction,
+      lerp: fractionLerp,
+    };
+    register(entry);
+
+    expect(interpolators.get('test/fraction')?.lerp).toBe(fractionLerp);
+    expect(interpolators.get('test/missing')).toBeNull();
+  });
+
+  test('Factories stamp produced functions with a descriptor', () => {
+    const factory =
+      (scale: number) => (from: number, to: number, value: number) =>
+        map(from, to, value) * scale;
+    const wrapped = interpolators.registerFactory('test/scaledLerp', factory, {
+      params: {scale: 'number'},
+    });
+
+    const lerp = wrapped(2);
+
+    expect(lerp(0, 10, 0.5)).toBe(10);
+    expect(interpolators.describe(lerp)).toEqual({
+      id: 'test/scaledLerp',
+      params: {scale: 2},
+    });
+    expect(interpolators.describe(factory(2))).toBeNull();
+  });
+
+  test('Registering a different factory under an existing id throws', () => {
+    const factory = () => (from: number, to: number, value: number) =>
+      map(from, to, value);
+    interpolators.registerFactory('test/conflicting', factory, {params: {}});
+
+    expect(() =>
+      interpolators.registerFactory(
+        'test/conflicting',
+        () => (from: number) => from,
+        {params: {}},
+      ),
+    ).toThrow('interpolators.registerFactory("test/conflicting")');
+    expect(() =>
+      interpolators.registerFactory('test/conflicting', factory, {params: {}}),
+    ).not.toThrow();
+  });
+
+  test('Non-serializable arguments skip the stamp and warn once', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const factory =
+      (pick: () => number) => (from: number, to: number, value: number) =>
+        map(from, to, value) * pick();
+    const wrapped = interpolators.registerFactory('test/pickedLerp', factory, {
+      params: {pick: 'function'},
+    });
+
+    const first = wrapped(() => 1);
+    const second = wrapped(() => 2);
+
+    expect(interpolators.describe(first)).toBeNull();
+    expect(interpolators.describe(second)).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  test('Non-finite numbers are not serializable', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const factory =
+      (scale: number) => (from: number, to: number, value: number) =>
+        map(from, to, value) * scale;
+    const wrapped = interpolators.registerFactory('test/finiteLerp', factory, {
+      params: {scale: 'number'},
+    });
+
+    expect(interpolators.describe(wrapped(NaN))).toBeNull();
+    expect(interpolators.describe(wrapped(Infinity))).toBeNull();
+    expect(interpolators.describe(wrapped(2))).toEqual({
+      id: 'test/finiteLerp',
+      params: {scale: 2},
+    });
+    warn.mockRestore();
+  });
+
+  test('Undefined arguments are omitted from the descriptor', () => {
+    expect(interpolators.describe(Vector2.createPolarLerp())).toEqual({
+      id: 'core/polarLerp',
+      params: {},
+    });
+  });
+
+  test('Vector2.createPolarLerp carries a descriptor', () => {
+    const lerp = Vector2.createPolarLerp(true, [120, 40]);
+
+    expect(interpolators.describe(lerp)).toEqual({
+      id: 'core/polarLerp',
+      params: {counterclockwise: true, center: [120, 40]},
+    });
+    expect(
+      interpolators.describe(Vector2.createPolarLerp(false, new Vector2(1, 2))),
+    ).toEqual({
+      id: 'core/polarLerp',
+      params: {counterclockwise: false, center: {x: 1, y: 2}},
+    });
+
+    const from = new Vector2(100, 0);
+    const to = new Vector2(-100, 0);
+    expect(lerp(from, to, 0.5)).toEqual(
+      Vector2.polarLerp(from, to, 0.5, true, new Vector2(120, 40)),
+    );
+  });
+});

--- a/packages/core/src/tweening/interpolators.ts
+++ b/packages/core/src/tweening/interpolators.ts
@@ -1,0 +1,324 @@
+import {useLogger} from '../utils';
+import type {InterpolationFunction} from './interpolationFunctions';
+
+/**
+ * A named interpolator that can be picked at runtime based on the
+ * interpolated values.
+ */
+export interface InterpolatorEntry<T> {
+  /**
+   * The unique name identifying this interpolator.
+   */
+  name: string;
+  /**
+   * Check if this interpolator can handle the given pair of values.
+   */
+  test(a: unknown, b: unknown): boolean;
+  /**
+   * The interpolation function to use when {@link test} passes.
+   */
+  lerp(from: T, to: T, value: number): T;
+  /**
+   * Entries with a higher priority win over lower ones. Defaults to `0`.
+   */
+  priority?: number;
+}
+
+/**
+ * A serializable identity of a factory-produced interpolation function.
+ */
+export interface InterpolatorDescriptor {
+  id: string;
+  params: Record<string, unknown>;
+}
+
+/**
+ * Options for {@link interpolators.registerFactory}.
+ */
+export interface InterpolatorFactoryOptions {
+  /**
+   * The factory's parameter names, in positional order, mapped to a
+   * human-readable description of their type.
+   *
+   * @remarks
+   * The names key the produced descriptor's `params`; the descriptions are
+   * documentation and are not validated against at runtime.
+   */
+  params: Record<string, string>;
+}
+
+interface RegisteredEntry {
+  entry: InterpolatorEntry<unknown>;
+  priority: number;
+  count: number;
+}
+
+interface RegisteredFactory {
+  factory: unknown;
+  params: Record<string, string>;
+}
+
+const Registry = new Map<string, RegisteredEntry>();
+const Factories = new Map<string, RegisteredFactory>();
+const Descriptors = new WeakMap<object, InterpolatorDescriptor>();
+const WarnedFactories = new Set<string>();
+
+function serializeValue(value: unknown): {value: unknown} | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? {value} : null;
+  }
+
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'string'
+  ) {
+    return {value};
+  }
+
+  if (Array.isArray(value)) {
+    const values: unknown[] = [];
+    for (const element of value) {
+      const serialized = serializeValue(element);
+      if (serialized === null) {
+        return null;
+      }
+      values.push(serialized.value);
+    }
+    return {value: values};
+  }
+
+  if (typeof value === 'object') {
+    if ('serialize' in value && typeof value.serialize === 'function') {
+      const serialized: unknown = value.serialize();
+      return serialized === value ? null : serializeValue(serialized);
+    }
+
+    const prototype = Object.getPrototypeOf(value) as object | null;
+    if (prototype === Object.prototype || prototype === null) {
+      const values: Record<string, unknown> = {};
+      for (const [key, element] of Object.entries(value)) {
+        const serialized = serializeValue(element);
+        if (serialized === null) {
+          return null;
+        }
+        values[key] = serialized.value;
+      }
+      return {value: values};
+    }
+  }
+
+  return null;
+}
+
+function serializeParams(
+  id: string,
+  names: string[],
+  args: unknown[],
+): Record<string, unknown> | null {
+  const params: Record<string, unknown> = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === undefined) {
+      continue;
+    }
+    const serialized = serializeValue(args[i]);
+    if (serialized === null) {
+      if (!WarnedFactories.has(id)) {
+        WarnedFactories.add(id);
+        useLogger().warn(
+          `interpolators.registerFactory("${id}"): called with non-serializable arguments, the produced interpolator will not carry a descriptor.`,
+        );
+      }
+      return null;
+    }
+    params[names[i] ?? `${i}`] = serialized.value;
+  }
+  return params;
+}
+
+/**
+ * A registry of named interpolation functions.
+ *
+ * @remarks
+ * Registered entries are consulted by signal tweens that have no explicit
+ * interpolation function configured, before falling back to
+ * {@link deepLerp}. Registered factories give the interpolation functions
+ * they produce a serializable `{id, params}` identity.
+ */
+export const interpolators = {
+  /**
+   * Register an interpolator.
+   *
+   * @remarks
+   * Names are unique: registering a different entry under an existing name
+   * throws, while re-registering an identical entry is a no-op. Ties in
+   * {@link InterpolatorEntry.priority} are broken by registration order.
+   *
+   * @example
+   * ```ts
+   * const uninstall = interpolators.register({
+   *   name: 'myLibrary/quaternion',
+   *   test: (a, b) => a instanceof Quaternion && b instanceof Quaternion,
+   *   lerp: Quaternion.slerp,
+   * });
+   * ```
+   *
+   * @param entry - The interpolator to register.
+   *
+   * @returns A function that removes the entry from the registry.
+   */
+  register<T>(entry: InterpolatorEntry<T>): () => void {
+    const existing = Registry.get(entry.name);
+    let record: RegisteredEntry;
+    if (existing) {
+      if (
+        existing.entry.test !== entry.test ||
+        existing.entry.lerp !== entry.lerp ||
+        existing.priority !== (entry.priority ?? 0)
+      ) {
+        throw new Error(
+          `interpolators.register("${entry.name}"): already registered with a different implementation`,
+        );
+      }
+      record = existing;
+      record.count++;
+    } else {
+      record = {entry, priority: entry.priority ?? 0, count: 1};
+      Registry.set(entry.name, record);
+    }
+
+    let active = true;
+    return () => {
+      if (!active || Registry.get(entry.name) !== record) {
+        return;
+      }
+      active = false;
+      record.count--;
+      if (record.count === 0) {
+        Registry.delete(entry.name);
+      }
+    };
+  },
+
+  /**
+   * Find an interpolation function for the given pair of values.
+   *
+   * @example
+   * ```ts
+   * const lerp = interpolators.find(from, to) ?? deepLerp;
+   * ```
+   *
+   * @param a - The value interpolated from.
+   * @param b - The value interpolated to.
+   *
+   * @returns The interpolation function of the highest-priority entry whose
+   *          test passes, or `null` if none match.
+   */
+  find<T = unknown>(a: unknown, b: unknown): InterpolationFunction<T> | null {
+    let best: RegisteredEntry | null = null;
+    for (const record of Registry.values()) {
+      if (
+        (best === null || record.priority > best.priority) &&
+        record.entry.test(a, b)
+      ) {
+        best = record;
+      }
+    }
+
+    if (best === null) {
+      return null;
+    }
+
+    const {lerp} = best.entry;
+    // The entry's test vouches for the values this function receives.
+    return (from: T, to: T, value: number) => lerp(from, to, value) as T;
+  },
+
+  /**
+   * Look up a registered interpolator by name.
+   *
+   * @example
+   * ```ts
+   * const entry = interpolators.get('myLibrary/quaternion');
+   * ```
+   *
+   * @param name - The name of the interpolator.
+   */
+  get(name: string): InterpolatorEntry<unknown> | null {
+    return Registry.get(name)?.entry ?? null;
+  },
+
+  /**
+   * Register a factory of interpolation functions.
+   *
+   * @remarks
+   * The returned wrapper stamps every interpolation function it produces
+   * with a serializable `{id, params}` descriptor, retrievable through
+   * {@link interpolators.describe}. Arguments that can't be serialized -
+   * functions, symbols, or non-plain objects without a `serialize` method -
+   * skip the stamp and log a one-time warning.
+   *
+   * Ids are unique: registering a different factory under an existing id
+   * throws, while re-registering the same factory is a no-op.
+   *
+   * @example
+   * ```ts
+   * Vector2.createPolarLerp = interpolators.registerFactory(
+   *   'core/polarLerp',
+   *   Vector2.createPolarLerp,
+   *   {params: {counterclockwise: 'boolean', center: 'Vector2'}},
+   * );
+   * ```
+   *
+   * @param id - The unique id identifying the factory.
+   * @param factory - The factory to wrap.
+   * @param options - The factory's parameter schema, in positional order.
+   *
+   * @returns A wrapper with the same signature as the factory.
+   */
+  registerFactory<TArgs extends unknown[], T>(
+    id: string,
+    factory: (...args: TArgs) => InterpolationFunction<T>,
+    options: InterpolatorFactoryOptions,
+  ): (...args: TArgs) => InterpolationFunction<T> {
+    const existing = Factories.get(id);
+    if (existing && existing.factory !== factory) {
+      throw new Error(
+        `interpolators.registerFactory("${id}"): already registered with a different factory`,
+      );
+    }
+    if (!existing) {
+      Factories.set(id, {factory, params: options.params});
+    }
+
+    const names = Object.keys(options.params);
+    return (...args: TArgs) => {
+      const fn = factory(...args);
+      const params = serializeParams(id, names, args);
+      if (params !== null) {
+        Descriptors.set(fn, {id, params});
+      }
+      return fn;
+    };
+  },
+
+  /**
+   * Retrieve the descriptor of a factory-produced interpolation function.
+   *
+   * @example
+   * ```ts
+   * const descriptor = interpolators.describe(
+   *   Vector2.createPolarLerp(true, [120, 40]),
+   * );
+   * // {id: 'core/polarLerp', params: {counterclockwise: true, center: [120, 40]}}
+   * ```
+   *
+   * @param fn - An interpolation function produced by a registered factory.
+   *
+   * @returns The `{id, params}` descriptor, or `null` if the function wasn't
+   *          produced by a registered factory.
+   */
+  describe<T>(fn: InterpolationFunction<T>): InterpolatorDescriptor | null {
+    return Descriptors.get(fn) ?? null;
+  },
+};

--- a/packages/core/src/types/Vector.ts
+++ b/packages/core/src/types/Vector.ts
@@ -10,6 +10,7 @@ import {
   clamp,
   map,
 } from '../tweening/interpolationFunctions';
+import {interpolators} from '../tweening/interpolators';
 import {DEG2RAD, RAD2DEG} from '../utils';
 import {Matrix2D, PossibleMatrix2D} from './Matrix2D';
 import {Direction, Origin} from './Origin';
@@ -554,3 +555,9 @@ export class Vector2 implements Type, WebGLConvertible {
     yield this.y;
   }
 }
+
+Vector2.createPolarLerp = interpolators.registerFactory(
+  'core/polarLerp',
+  Vector2.createPolarLerp,
+  {params: {counterclockwise: 'boolean', center: 'Vector2'}},
+);


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

<!--
Please check these boxes. If a checkbox is not applicable, you can leave it unchecked.
-->

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create one first).
- [ ] **Mandatory**: The issue has been accepted (indicated by a [`c-accepted`][label-accepted] label) and is assigned to me.
- [x] **Mandatory**: I have read and understood the [AI policy][ai-policy].
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. I have added an `Assisted-by: <tool name / model>` trailer to the commit message.

## Summary

Add `SignalContext.extend` for swapping a signal's getter, setter, or tweener after construction. Add the `interpolators` registry: named interpolators back default tweens before `deepLerp`, and registered factories like `Vector2.createPolarLerp` produce functions carrying `{id, params}` descriptors.

This is a piece of allowing users to override behavior when they know what they're doing. It's also a step towards being able to export animations as data by producing a registry of interpolators.

## Test Plan

Needs testing with an example case where we don't have a good strategy pattern; maybe pretending we don't have the `morpher` prop for Latex. This maybe should replace some of how `deepLerp` works, but we'll see.

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

[ai-policy]: https://github.com/canvas-commons/.github/blob/main/AI_POLICY.md
[label-accepted]: https://github.com/canvas-commons/canvas-commons/issues?q=state%3Aopen%20label%3Ac-accepted
