### PR TITLE
feat(2d): add extendNode and onInit extension API

### DIFF
--- a/.changeset/extend-node-plugin-api.md
+++ b/.changeset/extend-node-plugin-api.md
@@ -1,0 +1,18 @@
+---
+'@canvas-commons/2d': minor
+---
+
+Add `extendNode`/`onInit` for plugins to register properties, metadata
+decorations, and construction hooks on existing node classes without forking
+them. `dumpExtensions` inspects the resolved chain for debugging.
+
+```ts
+extendNode(
+  Shape,
+  {rough: {op: 'add', decorators: [initial(false), signal()]}},
+  {
+    identity: '@canvas-commons/rough',
+  },
+);
+onInit(Shape, shape => shape.rough(true), {identity: '@canvas-commons/rough'});
+```

--- a/packages/2d/src/lib/decorators/extendNode.test.ts
+++ b/packages/2d/src/lib/decorators/extendNode.test.ts
@@ -1,0 +1,513 @@
+import {SimpleSignal} from '@canvas-commons/core';
+import {describe, expect, test, vi} from 'vitest';
+import {computed} from './computed';
+import {dumpExtensions, extendNode, onInit} from './extendNode';
+import {
+  getPropertiesOf,
+  initial,
+  initializeSignals,
+  parser,
+  signal,
+} from './signal';
+
+interface Roughable {
+  rough: SimpleSignal<boolean>;
+}
+
+describe('extendNode: add', () => {
+  test('contributes a working signal, visible and constructible on subclasses declared before registration', () => {
+    class Base {
+      public constructor(props: {rough?: boolean} = {}) {
+        initializeSignals(this, props);
+      }
+    }
+
+    class Derived extends Base {}
+
+    extendNode(
+      Base,
+      {rough: {op: 'add', decorators: [initial(false), signal()]}},
+      {identity: '@canvas-commons/rough'},
+    );
+
+    expect(Object.keys(getPropertiesOf(Derived))).toContain('rough');
+
+    const instance = new Derived({rough: true}) as Derived & Roughable;
+    expect(instance.rough()).toBe(true);
+
+    const defaulted = new Derived() as Derived & Roughable;
+    expect(defaulted.rough()).toBe(false);
+  });
+
+  test('throws when the property already exists as an own property', () => {
+    class Owner {
+      @initial(1)
+      @signal()
+      declare public readonly length: SimpleSignal<number>;
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    expect(() =>
+      extendNode(
+        Owner,
+        {length: {op: 'add', decorators: [initial(2), signal()]}},
+        {identity: '@canvas-commons/other'},
+      ),
+    ).toThrow(/length/);
+  });
+
+  test('throws when the property already exists on an inherited class, naming both identities', () => {
+    class Base {
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    class Derived extends Base {}
+
+    extendNode(
+      Base,
+      {tint: {op: 'add', decorators: [initial('red'), signal()]}},
+      {identity: '@canvas-commons/first'},
+    );
+
+    expect(() =>
+      extendNode(
+        Derived,
+        {tint: {op: 'add', decorators: [initial('blue'), signal()]}},
+        {identity: '@canvas-commons/second'},
+      ),
+    ).toThrow(
+      /@canvas-commons\/second.*@canvas-commons\/first|@canvas-commons\/first.*@canvas-commons\/second/s,
+    );
+  });
+});
+
+describe('extendNode: decorate', () => {
+  test('stacks two decorations on parser in registration order', () => {
+    class Owner {
+      @initial(0)
+      @parser((value: number) => value)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor(props: {value?: number} = {}) {
+        initializeSignals(this, props);
+      }
+    }
+
+    extendNode(
+      Owner,
+      {
+        value: {
+          op: 'decorate',
+          slot: 'parser',
+          wrap: next => (raw: number) => (next ? Number(next(raw)) : raw) + 1,
+        },
+      },
+      {identity: '@canvas-commons/plus-one'},
+    );
+
+    extendNode(
+      Owner,
+      {
+        value: {
+          op: 'decorate',
+          slot: 'parser',
+          wrap: next => (raw: number) => (next ? Number(next(raw)) : raw) * 2,
+        },
+      },
+      {identity: '@canvas-commons/times-two'},
+    );
+
+    const instance = new Owner();
+    instance.value(5);
+    expect(instance.value()).toBe((5 + 1) * 2);
+  });
+
+  test('decorates the tweener slot', () => {
+    class Owner {
+      @initial(0)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    const tweener = vi.fn();
+    extendNode(
+      Owner,
+      {
+        value: {
+          op: 'decorate',
+          slot: 'tweener',
+          wrap: () => tweener,
+        },
+      },
+      {identity: '@canvas-commons/custom-tweener'},
+    );
+
+    const meta = getPropertiesOf(Owner).value;
+    meta.tweener?.(
+      1,
+      1,
+      t => t,
+      (a, b, t) => a + (b - a) * t,
+    );
+    expect(tweener).toHaveBeenCalledOnce();
+  });
+
+  test('decorates the default slot', () => {
+    class Owner {
+      @initial(1)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    extendNode(
+      Owner,
+      {
+        value: {
+          op: 'decorate',
+          slot: 'default',
+          wrap: next => (typeof next === 'number' ? next * 10 : next),
+        },
+      },
+      {identity: '@canvas-commons/scaled-default'},
+    );
+
+    const instance = new Owner();
+    expect(instance.value()).toBe(10);
+  });
+});
+
+describe('extendNode: replace', () => {
+  test('works once; a second replace from a different identity throws naming both; the same identity is a no-op', () => {
+    class Owner {
+      @initial(0)
+      @parser((value: number) => value)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    const strict = (raw: number) => Math.max(0, raw);
+    extendNode(
+      Owner,
+      {value: {op: 'replace', slot: 'parser', value: strict}},
+      {identity: '@canvas-commons/strict'},
+    );
+
+    expect(getPropertiesOf(Owner).value.parser).toBe(strict);
+
+    expect(() =>
+      extendNode(
+        Owner,
+        {
+          value: {
+            op: 'replace',
+            slot: 'parser',
+            value: (raw: number) => raw,
+          },
+        },
+        {identity: '@canvas-commons/other'},
+      ),
+    ).toThrow(/@canvas-commons\/strict/);
+
+    expect(() =>
+      extendNode(
+        Owner,
+        {
+          value: {
+            op: 'replace',
+            slot: 'parser',
+            value: (raw: number) => raw,
+          },
+        },
+        {identity: '@canvas-commons/other'},
+      ),
+    ).toThrow(/@canvas-commons\/other/);
+
+    extendNode(
+      Owner,
+      {value: {op: 'replace', slot: 'parser', value: strict}},
+      {identity: '@canvas-commons/strict'},
+    );
+    expect(getPropertiesOf(Owner).value.parser).toBe(strict);
+  });
+});
+
+describe('extendNode: idempotent re-registration', () => {
+  test('re-registering the same identity does not double-apply decorators or stack decorations again', () => {
+    class Owner {
+      public constructor(props: {rough?: boolean} = {}) {
+        initializeSignals(this, props);
+      }
+    }
+
+    const decorators = {
+      rough: {op: 'add' as const, decorators: [initial(false), signal()]},
+    };
+
+    extendNode(Owner, decorators, {identity: '@canvas-commons/rough'});
+    extendNode(Owner, decorators, {identity: '@canvas-commons/rough'});
+
+    const instance = new Owner() as Owner & Roughable;
+    expect(instance.rough()).toBe(false);
+
+    class Stacked {
+      @initial(1)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    const calls: number[] = [];
+    const stackOp = {
+      value: {
+        op: 'decorate' as const,
+        slot: 'default' as const,
+        wrap: (next: unknown) => {
+          calls.push(1);
+          return next;
+        },
+      },
+    };
+
+    extendNode(Stacked, stackOp, {identity: '@canvas-commons/stack'});
+    extendNode(Stacked, stackOp, {identity: '@canvas-commons/stack'});
+
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe('extendNode: atomicity', () => {
+  test('a registration with one invalid operation applies nothing', () => {
+    class Owner {
+      public constructor(props: {rough?: boolean} = {}) {
+        initializeSignals(this, props);
+      }
+    }
+
+    expect(() =>
+      extendNode(
+        Owner,
+        {
+          rough: {op: 'add', decorators: [initial(false), signal()]},
+          missing: {op: 'decorate', slot: 'default', wrap: next => next},
+        },
+        {identity: '@canvas-commons/partial'},
+      ),
+    ).toThrow(/missing/);
+
+    expect(Object.keys(getPropertiesOf(Owner))).not.toContain('rough');
+    expect(() => new Owner()).not.toThrow();
+  });
+
+  test('re-registering the same identity with different operations throws', () => {
+    class Owner {
+      public constructor(props: {rough?: boolean} = {}) {
+        initializeSignals(this, props);
+      }
+    }
+
+    extendNode(
+      Owner,
+      {rough: {op: 'add', decorators: [initial(false), signal()]}},
+      {identity: '@canvas-commons/drift'},
+    );
+
+    expect(() =>
+      extendNode(
+        Owner,
+        {smooth: {op: 'add', decorators: [initial(true), signal()]}},
+        {identity: '@canvas-commons/drift'},
+      ),
+    ).toThrow(/@canvas-commons\/drift.*different set of operations/);
+  });
+});
+
+describe('onInit', () => {
+  test('runs for the class and subclasses, once per construction, and is idempotent under re-registration', () => {
+    class Base {
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    class Derived extends Base {}
+
+    const hook = vi.fn();
+    onInit(Base, hook, {identity: '@canvas-commons/hook'});
+    onInit(Base, hook, {identity: '@canvas-commons/hook'});
+
+    new Base();
+    new Derived();
+
+    expect(hook).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('dumpExtensions', () => {
+  test('reports a base value plus a decoration in application order', () => {
+    class Owner {
+      @initial(1)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    extendNode(
+      Owner,
+      {
+        value: {
+          op: 'decorate',
+          slot: 'default',
+          wrap: next => next,
+        },
+      },
+      {identity: '@canvas-commons/dump-me'},
+    );
+
+    const dump = dumpExtensions(Owner, 'value');
+    expect(dump.property).toBe('value');
+    expect(dump.base?.default).toBe(1);
+    expect(dump.entries).toEqual([
+      {identity: '@canvas-commons/dump-me', op: 'decorate', slot: 'default'},
+    ]);
+  });
+});
+
+describe('extendNode: decorate targets the declaring class', () => {
+  test('throws when the property is declared on an ancestor, naming it', () => {
+    class Base {
+      @initial(1)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    class Derived extends Base {}
+
+    expect(() =>
+      extendNode(
+        Derived,
+        {value: {op: 'decorate', slot: 'default', wrap: next => next}},
+        {identity: '@canvas-commons/misplaced'},
+      ),
+    ).toThrow(/declared on Base/);
+  });
+
+  test('throws when the property does not exist', () => {
+    class Owner {
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    expect(() =>
+      extendNode(
+        Owner,
+        {missing: {op: 'decorate', slot: 'default', wrap: next => next}},
+        {identity: '@canvas-commons/typo'},
+      ),
+    ).toThrow(/not declared on Owner/);
+  });
+});
+
+describe('decorate shadowing semantics', () => {
+  test('a base-class decoration does not apply once a subclass redeclares the property with @signal', () => {
+    class Base {
+      @initial(1)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    extendNode(
+      Base,
+      {
+        value: {
+          op: 'decorate',
+          slot: 'default',
+          wrap: () => 99,
+        },
+      },
+      {identity: '@canvas-commons/base-decoration'},
+    );
+
+    expect(new Base().value()).toBe(99);
+
+    class Redeclared extends Base {
+      @initial(1)
+      @signal()
+      declare public readonly value: SimpleSignal<number>;
+
+      public constructor() {
+        super();
+      }
+    }
+
+    expect(new Redeclared().value()).toBe(1);
+  });
+});
+
+describe('onInit contributing a computed-style method', () => {
+  test('contributes a cached computed method via onInit', () => {
+    class Owner {
+      public label() {
+        return 'base';
+      }
+
+      public constructor() {
+        initializeSignals(this, {});
+      }
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Owner.prototype,
+      'label',
+    );
+    if (!descriptor) {
+      throw new Error('expected "label" to be declared on Owner');
+    }
+    computed()(Owner.prototype, 'label', descriptor);
+
+    onInit(
+      Owner,
+      instance => {
+        const method = instance.label;
+        instance.label = () => `computed:${method.call(instance)}`;
+      },
+      {identity: '@canvas-commons/computed-label'},
+    );
+
+    class Derived extends Owner {}
+
+    expect(new Derived().label()).toBe('computed:base');
+  });
+});

--- a/packages/2d/src/lib/decorators/extendNode.ts
+++ b/packages/2d/src/lib/decorators/extendNode.ts
@@ -1,0 +1,376 @@
+import {addInitializer, Constructor, Initializer} from './initializers';
+import {
+  getPropertiesOf,
+  getPropertyMeta,
+  invalidatePropertyMetaCache,
+  PropertyMetadata,
+} from './signal';
+
+export type ExtensionSlot = 'tweener' | 'parser' | 'interpolation' | 'default';
+
+type SlotValue<
+  TSlot extends ExtensionSlot,
+  TValue = unknown,
+> = TSlot extends 'tweener'
+  ? PropertyMetadata<TValue>['tweener']
+  : TSlot extends 'parser'
+    ? PropertyMetadata<TValue>['parser']
+    : TSlot extends 'interpolation'
+      ? PropertyMetadata<TValue>['interpolationFunction']
+      : PropertyMetadata<TValue>['default'];
+
+export interface AddOperation {
+  op: 'add';
+  decorators: PropertyDecorator[];
+}
+
+export interface DecorateOperation<
+  TSlot extends ExtensionSlot,
+  TValue = unknown,
+> {
+  op: 'decorate';
+  slot: TSlot;
+  wrap: (next: SlotValue<TSlot, TValue>) => SlotValue<TSlot, TValue>;
+}
+
+export interface ReplaceOperation<
+  TSlot extends ExtensionSlot,
+  TValue = unknown,
+> {
+  op: 'replace';
+  slot: TSlot;
+  value: SlotValue<TSlot, TValue>;
+}
+
+type AnyDecorateOperation = {
+  [TSlot in ExtensionSlot]: DecorateOperation<TSlot>;
+}[ExtensionSlot];
+
+type AnyReplaceOperation = {
+  [TSlot in ExtensionSlot]: ReplaceOperation<TSlot>;
+}[ExtensionSlot];
+
+export type ExtensionOperation =
+  | AddOperation
+  | AnyDecorateOperation
+  | AnyReplaceOperation;
+
+export interface ExtendNodeOptions {
+  identity: string;
+}
+
+interface AppliedOperation {
+  identity: string;
+  operation: ExtensionOperation;
+}
+
+const EXTENSIONS = Symbol.for('@canvas-commons/2d/decorators/extensions');
+const APPLIED_IDENTITIES = Symbol.for(
+  '@canvas-commons/2d/decorators/extensions/applied',
+);
+
+type ExtensionLog = Record<string, AppliedOperation[]>;
+
+function getOwnExtensionLog(target: object): ExtensionLog | null {
+  return Object.prototype.hasOwnProperty.call(target, EXTENSIONS)
+    ? (target as Record<symbol, ExtensionLog>)[EXTENSIONS]
+    : null;
+}
+
+function getAppliedLog(target: object, property: string): AppliedOperation[] {
+  if (!Object.prototype.hasOwnProperty.call(target, EXTENSIONS)) {
+    (target as Record<symbol, ExtensionLog>)[EXTENSIONS] = {};
+  }
+  const lookup = (target as Record<symbol, ExtensionLog>)[EXTENSIONS];
+  lookup[property] ??= [];
+  return lookup[property];
+}
+
+function getAppliedRegistry(target: object): Map<string, string> {
+  if (!Object.prototype.hasOwnProperty.call(target, APPLIED_IDENTITIES)) {
+    (target as Record<symbol, Map<string, string>>)[APPLIED_IDENTITIES] =
+      new Map();
+  }
+  return (target as Record<symbol, Map<string, string>>)[APPLIED_IDENTITIES];
+}
+
+function fingerprintOf(operations: Record<string, ExtensionOperation>): string {
+  return Object.entries(operations)
+    .map(([property, operation]) =>
+      operation.op === 'add'
+        ? `${property}:add:${operation.decorators.length}`
+        : `${property}:${operation.op}:${operation.slot}`,
+    )
+    .sort()
+    .join(',');
+}
+
+function chainOf(target: object): object[] {
+  const chain: object[] = [];
+  let prototype: object | null = target;
+  while (prototype && prototype !== Object.prototype) {
+    chain.push(prototype);
+    prototype = Object.getPrototypeOf(prototype) as object | null;
+  }
+  return chain;
+}
+
+function findAdder(target: object, property: string): string | null {
+  for (const prototype of chainOf(target)) {
+    const log = getOwnExtensionLog(prototype)?.[property];
+    const entry = log?.find(applied => applied.operation.op === 'add');
+    if (entry) {
+      return entry.identity;
+    }
+  }
+  return null;
+}
+
+function applyAdd(
+  target: object,
+  property: string,
+  identity: string,
+  operation: AddOperation,
+) {
+  for (let i = operation.decorators.length - 1; i >= 0; i--) {
+    operation.decorators[i](target, property);
+  }
+
+  getAppliedLog(target, property).push({identity, operation});
+}
+
+function requireOwnMeta(
+  target: object,
+  property: string,
+  identity: string,
+  op: string,
+): PropertyMetadata<unknown> {
+  const own = getPropertyMeta<unknown>(target, property);
+  if (own) {
+    return own;
+  }
+  const declaring = chainOf(target).find(prototype =>
+    getPropertyMeta(prototype, property),
+  );
+  if (declaring) {
+    throw new Error(
+      `extendNode("${identity}"): cannot ${op} property "${property}", it is declared on ${declaring.constructor.name}; extend that class instead`,
+    );
+  }
+  throw new Error(
+    `extendNode("${identity}"): cannot ${op} property "${property}", it is not declared on ${target.constructor.name}`,
+  );
+}
+
+function applyDecorate(
+  target: object,
+  property: string,
+  identity: string,
+  operation: AnyDecorateOperation,
+) {
+  const meta = requireOwnMeta(target, property, identity, 'decorate');
+  switch (operation.slot) {
+    case 'tweener':
+      meta.tweener = operation.wrap(meta.tweener);
+      break;
+    case 'parser':
+      meta.parser = operation.wrap(meta.parser);
+      break;
+    case 'interpolation':
+      meta.interpolationFunction = operation.wrap(meta.interpolationFunction);
+      break;
+    case 'default':
+      meta.default = operation.wrap(meta.default);
+      break;
+  }
+  invalidatePropertyMetaCache();
+
+  getAppliedLog(target, property).push({identity, operation});
+}
+
+function checkOperation(
+  target: object,
+  property: string,
+  identity: string,
+  operation: ExtensionOperation,
+) {
+  if (operation.op === 'add') {
+    if (property in getPropertiesOf(target)) {
+      const adder = findAdder(target, property);
+      const owner = adder ? `by "${adder}"` : 'outside of extendNode';
+      throw new Error(
+        `extendNode("${identity}"): cannot add property "${property}", it is already declared ${owner}`,
+      );
+    }
+    return;
+  }
+
+  requireOwnMeta(target, property, identity, operation.op);
+  if (operation.op === 'replace') {
+    const conflict = getAppliedLog(target, property).find(
+      entry =>
+        entry.operation.op === 'replace' &&
+        entry.operation.slot === operation.slot,
+    );
+    if (conflict) {
+      throw new Error(
+        `extendNode("${identity}"): cannot replace slot "${operation.slot}" of property "${property}", already replaced by "${conflict.identity}"`,
+      );
+    }
+  }
+}
+
+function applyReplace(
+  target: object,
+  property: string,
+  identity: string,
+  operation: AnyReplaceOperation,
+) {
+  const meta = requireOwnMeta(target, property, identity, 'replace');
+  switch (operation.slot) {
+    case 'tweener':
+      meta.tweener = operation.value;
+      break;
+    case 'parser':
+      meta.parser = operation.value;
+      break;
+    case 'interpolation':
+      meta.interpolationFunction = operation.value;
+      break;
+    case 'default':
+      meta.default = operation.value;
+      break;
+  }
+  invalidatePropertyMetaCache();
+
+  getAppliedLog(target, property).push({identity, operation});
+}
+
+/**
+ * Register properties and metadata slot decorations on an existing node
+ * class.
+ *
+ * @remarks
+ * Re-registering the same identity with the same operations is a no-op; a
+ * different set throws. Operations are validated before any of them apply.
+ *
+ * @example
+ * ```ts
+ * extendNode(
+ *   Shape,
+ *   {
+ *     rough: {op: 'add', decorators: [initial(false), signal()]},
+ *   },
+ *   {identity: '@canvas-commons/rough'},
+ * );
+ * ```
+ */
+export function extendNode(
+  target: Constructor,
+  operations: Record<string, ExtensionOperation>,
+  {identity}: ExtendNodeOptions,
+) {
+  const prototype = target.prototype as object;
+  const registry = getAppliedRegistry(prototype);
+  const fingerprint = fingerprintOf(operations);
+  const registered = registry.get(identity);
+  if (registered !== undefined) {
+    if (registered !== fingerprint) {
+      throw new Error(
+        `extendNode("${identity}"): already registered on ${prototype.constructor.name} with a different set of operations`,
+      );
+    }
+    return;
+  }
+
+  const entries = Object.entries(operations);
+  for (const [property, operation] of entries) {
+    checkOperation(prototype, property, identity, operation);
+  }
+  for (const [property, operation] of entries) {
+    if (operation.op === 'add') {
+      applyAdd(prototype, property, identity, operation);
+    } else if (operation.op === 'decorate') {
+      applyDecorate(prototype, property, identity, operation);
+    } else {
+      applyReplace(prototype, property, identity, operation);
+    }
+  }
+
+  registry.set(identity, fingerprint);
+}
+
+/**
+ * Register a construction-time hook for every instance of the given class
+ * and its subclasses. Re-registering the same identity is a no-op.
+ *
+ * @example
+ * ```ts
+ * onInit(Shape, shape => shape.rough(true), {identity: '@canvas-commons/rough'});
+ * ```
+ */
+export function onInit<T extends Constructor>(
+  target: T,
+  initializer: Initializer<InstanceType<T>>,
+  {identity}: ExtendNodeOptions,
+) {
+  const prototype = target.prototype as object;
+  const registry = getAppliedRegistry(prototype);
+  const key = `onInit:${identity}`;
+  if (registry.has(key)) {
+    return;
+  }
+
+  addInitializer(prototype, initializer);
+  registry.set(key, 'onInit');
+}
+
+export interface ExtensionDumpEntry {
+  identity: string;
+  op: ExtensionOperation['op'];
+  slot?: ExtensionSlot;
+}
+
+export interface ExtensionDump {
+  property: string;
+  base: PropertyMetadata<unknown> | null;
+  entries: ExtensionDumpEntry[];
+}
+
+/**
+ * Resolve the chain of contributions made to a property via
+ * {@link extendNode}, in application order.
+ *
+ * @example
+ * ```ts
+ * const dump = dumpExtensions(Shape, 'rough');
+ * ```
+ */
+export function dumpExtensions(
+  target: Constructor,
+  property: string,
+): ExtensionDump {
+  const resolved = getPropertiesOf(target);
+  const chain = chainOf(target.prototype as object);
+
+  const entries: ExtensionDumpEntry[] = [];
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const log = getOwnExtensionLog(chain[i])?.[property];
+    if (!log) {
+      continue;
+    }
+    for (const {identity, operation} of log) {
+      entries.push({
+        identity,
+        op: operation.op,
+        slot: operation.op === 'add' ? undefined : operation.slot,
+      });
+    }
+  }
+
+  return {
+    property,
+    base: resolved[property] ?? null,
+    entries,
+  };
+}

--- a/packages/2d/src/lib/decorators/index.ts
+++ b/packages/2d/src/lib/decorators/index.ts
@@ -3,6 +3,7 @@ export * from './colorSignal';
 export * from './compound';
 export * from './computed';
 export * from './defaultStyle';
+export * from './extendNode';
 export * from './filtersSignal';
 export * from './initializers';
 export * from './nodeName';


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

<!--
Please check these boxes. If a checkbox is not applicable, you can leave it unchecked.
-->

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create one first).
- [ ] **Mandatory**: The issue has been accepted (indicated by a [`c-accepted`][label-accepted] label) and is assigned to me.
- [x] **Mandatory**: I have read and understood the [AI policy][ai-policy].
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. I have added an `Assisted-by: <tool name / model>` trailer to the commit message.

## Summary

Add `extendNode`/`onInit` for plugins to register properties, metadata decorations, and construction hooks on existing node classes without forking them. `dumpExtensions` inspects the resolved chain for debugging.

```ts
extendNode(
  Shape,
  {rough: {op: 'add', decorators: [initial(false), signal()]}},
  {
    identity: '@canvas-commons/rough',
  },
);

onInit(Shape, shape => shape.rough(true), {identity: '@canvas-commons/rough'});
```

[ai-policy]: https://github.com/canvas-commons/.github/blob/main/AI_POLICY.md
[label-accepted]: https://github.com/canvas-commons/canvas-commons/issues?q=state%3Aopen%20label%3Ac-accepted
