### PR TITLE
feat(2d): warn on unknown props, add pickProps helper

### DIFF
--- a/.changeset/signal-unknown-prop-warning.md
+++ b/.changeset/signal-unknown-prop-warning.md
@@ -1,0 +1,7 @@
+---
+'@canvas-commons/2d': minor
+---
+
+Warn once per class/prop when a node receives a prop that matches no declared
+property, a typo or a plugin that isn't registered. Add `pickProps` and
+`partialProps` to split a merged props object without triggering the warning.

--- a/packages/2d/src/lib/components/Node.ts
+++ b/packages/2d/src/lib/components/Node.ts
@@ -526,7 +526,7 @@ export class Node implements Promisable<Node> {
   public readonly key: string;
   public readonly creationStack?: string;
 
-  public constructor({children, spawner, key, ...rest}: NodeProps) {
+  public constructor({children, spawner, key, ref: _ref, ...rest}: NodeProps) {
     const scene = useScene2D();
     [this.key, this.unregister] = scene.registerNode(this, key);
     this.view2D = scene.getView();

--- a/packages/2d/src/lib/decorators/signal.test.ts
+++ b/packages/2d/src/lib/decorators/signal.test.ts
@@ -1,5 +1,7 @@
 import {CompoundSignal, DEFAULT, SimpleSignal} from '@canvas-commons/core';
-import {beforeEach, describe, expect, test, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {Node} from '../components';
+import {mockScene2D} from '../components/__tests__/mockScene2D';
 import {compound} from './compound';
 import {computed} from './computed';
 import {
@@ -306,5 +308,88 @@ describe('property metadata chain-walk', () => {
 
     expect(getPropertiesOf(Benchmarked)).toBe(propertiesBefore);
     expect(chainWalkCallsPerInstance).toBeLessThan(1);
+  });
+});
+
+describe('initializeSignals: unknown prop warning', () => {
+  mockScene2D();
+
+  class Warnable {
+    @initial(0)
+    @signal()
+    declare public readonly length: SimpleSignal<number>;
+
+    @initial({x: 0, y: 0})
+    @parser((value: {x: number; y: number}) => value)
+    @compound({x: 'positionX', y: 'positionY'})
+    declare public readonly position: CompoundSignal<
+      {x: number; y: number},
+      {x: number; y: number}
+    >;
+
+    public constructor(props: Record<string, any> = {}) {
+      initializeSignals(this, props);
+    }
+  }
+  class OtherWarnable {
+    public constructor(props: Record<string, any> = {}) {
+      initializeSignals(this, props);
+    }
+  }
+
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('warns on a prop that matches no declared property', () => {
+    new Warnable({unknownPropA: 5});
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0][0]).toContain('unknownPropA');
+    expect(warnSpy.mock.calls[0][0]).toContain('Warnable');
+  });
+
+  test('does not warn for a declared property', () => {
+    new Warnable({length: 5});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('does not warn for a compound sub-prop', () => {
+    new Warnable({positionX: 5, positionY: 5});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('does not warn for an undefined-valued key', () => {
+    new Warnable({unknownPropB: undefined});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('does not warn for children, key, or ref, which Node strips before initializeSignals sees them', () => {
+    new Node({children: [], key: 'my-key', ref: () => {}});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('warns once per (constructor, prop) across multiple constructions', () => {
+    new Warnable({unknownPropC: 1});
+    new Warnable({unknownPropC: 2});
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  test('warns separately for the same prop name on a different constructor', () => {
+    new Warnable({unknownPropD: 1});
+    new OtherWarnable({unknownPropD: 1});
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/2d/src/lib/decorators/signal.ts
+++ b/packages/2d/src/lib/decorators/signal.ts
@@ -42,6 +42,13 @@ const PropertyChainCache = new WeakMap<
   {epoch: number; properties: Record<string, PropertyMetadata<any>>}
 >();
 
+const KnownKeysCache = new WeakMap<
+  Record<string, PropertyMetadata<any>>,
+  Set<string>
+>();
+
+const WarnedUnknownProps = new WeakMap<Constructor, Set<string>>();
+
 export function getPropertyMeta<T>(
   target: any,
   key: string | symbol,
@@ -104,9 +111,27 @@ export function getPropertiesOf(
   return properties;
 }
 
+export function getKnownPropKeysOf(value: any): Set<string> {
+  const properties = getPropertiesOf(value);
+  let known = KnownKeysCache.get(properties);
+  if (known) {
+    return known;
+  }
+
+  known = new Set(Object.keys(properties));
+  for (const meta of Object.values(properties)) {
+    for (const [, property] of meta.compoundEntries) {
+      known.add(property);
+    }
+  }
+  KnownKeysCache.set(properties, known);
+  return known;
+}
+
 export function initializeSignals(instance: any, props: Record<string, any>) {
   initialize(instance);
-  for (const [key, meta] of Object.entries(getPropertiesOf(instance))) {
+  const properties = getPropertiesOf(instance);
+  for (const [key, meta] of Object.entries(properties)) {
     const signal = instance[key];
     signal.reset();
     if (props[key] !== undefined) {
@@ -119,6 +144,27 @@ export function initializeSignals(instance: any, props: Record<string, any>) {
         }
       }
     }
+  }
+
+  const known = getKnownPropKeysOf(instance);
+  for (const key of Object.keys(props)) {
+    if (known.has(key) || props[key] === undefined) {
+      continue;
+    }
+
+    let warned = WarnedUnknownProps.get(instance.constructor);
+    if (!warned) {
+      warned = new Set();
+      WarnedUnknownProps.set(instance.constructor, warned);
+    }
+    if (warned.has(key)) {
+      continue;
+    }
+    warned.add(key);
+
+    useLogger().warn(
+      `${instance.constructor.name} received an unknown prop "${key}"; it will be ignored. This usually means a typo, or the plugin that registers this property isn't installed in this project.`,
+    );
   }
 }
 

--- a/packages/2d/src/lib/utils/index.ts
+++ b/packages/2d/src/lib/utils/index.ts
@@ -2,5 +2,6 @@ export * from './CanvasUtils';
 export * from './fonts';
 export * from './is';
 export * from './PathDataBuilder';
+export * from './pickProps';
 export * from './rough';
 export * from './withDefaults';

--- a/packages/2d/src/lib/utils/pickProps.test.ts
+++ b/packages/2d/src/lib/utils/pickProps.test.ts
@@ -1,0 +1,92 @@
+import {SimpleSignal} from '@canvas-commons/core';
+import {describe, expect, test, vi} from 'vitest';
+import {Node, NodeProps} from '../components';
+import {mockScene2D} from '../components/__tests__/mockScene2D';
+import {compound} from '../decorators/compound';
+import {initial, parser, signal} from '../decorators/signal';
+import {partialProps, pickProps} from './pickProps';
+
+interface FillableProps extends NodeProps {
+  fill?: string;
+}
+
+class Fillable extends Node {
+  @initial('white')
+  @signal()
+  declare public readonly fill: SimpleSignal<string>;
+
+  public constructor(props: FillableProps = {}) {
+    super(props);
+  }
+}
+
+interface LanguageableProps extends NodeProps {
+  language?: string;
+  offset?: {x: number; y: number};
+}
+
+class Languageable extends Node {
+  @initial('')
+  @signal()
+  declare public readonly language: SimpleSignal<string>;
+
+  @initial({x: 0, y: 0})
+  @parser((value: {x: number; y: number}) => value)
+  @compound({x: 'offsetX', y: 'offsetY'})
+  declare public readonly offset: {x: number; y: number};
+
+  public constructor(props: LanguageableProps = {}) {
+    super(props);
+  }
+}
+
+describe('pickProps', () => {
+  mockScene2D();
+
+  test('picks declared props and compound sub-props, dropping the rest', () => {
+    const merged = {
+      fill: 'red',
+      language: 'tsx',
+      offsetX: 10,
+      offsetY: 20,
+      bogus: true,
+    };
+
+    expect(pickProps(Fillable, merged)).toEqual({fill: 'red'});
+    expect(pickProps(Languageable, merged)).toEqual({
+      language: 'tsx',
+      offsetX: 10,
+      offsetY: 20,
+    });
+  });
+
+  test('is warning-free when spread into the class it was picked for', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const merged = {fill: 'red', language: 'tsx', bogus: true};
+
+    new Fillable(pickProps(Fillable, merged));
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('accepts a named props interface without an index signature', () => {
+    interface MergedProps extends FillableProps, LanguageableProps {}
+
+    const merged: MergedProps = {fill: 'red', language: 'tsx'};
+
+    expect(pickProps(Fillable, merged)).toEqual({fill: 'red'});
+    expect(partialProps(['language'], merged)).toEqual({language: 'tsx'});
+  });
+});
+
+describe('partialProps', () => {
+  test('picks exactly the named keys', () => {
+    const props = {fill: 'red', stroke: 'blue', x: 10};
+
+    expect(partialProps(['fill', 'stroke'], props)).toEqual({
+      fill: 'red',
+      stroke: 'blue',
+    });
+  });
+});

--- a/packages/2d/src/lib/utils/pickProps.ts
+++ b/packages/2d/src/lib/utils/pickProps.ts
@@ -1,0 +1,64 @@
+import {NodeConstructor, PropsOf} from '../components/types';
+import {getKnownPropKeysOf} from '../decorators/signal';
+
+/**
+ * Pick only the props declared on the given class out of a larger props
+ * object, so a merged props object can spread across multiple components.
+ *
+ * @remarks
+ * Structural props (`ref`, `children`, `key`) are never picked; pass those
+ * explicitly on the component that owns them.
+ *
+ * @example
+ * ```tsx
+ * interface CodeEditorProps extends RectProps, CodeProps {}
+ *
+ * function CodeEditor(props: CodeEditorProps) {
+ *   return (
+ *     <Rect {...pickProps(Rect, props)}>
+ *       <Code {...pickProps(Code, props)} />
+ *     </Rect>
+ *   );
+ * }
+ * ```
+ *
+ * @param component - The class whose declared props should be picked.
+ * @param props - The props object to pick from.
+ */
+export function pickProps<T extends NodeConstructor>(
+  component: T,
+  props: Partial<PropsOf<T>>,
+): Partial<PropsOf<T>> {
+  const known = getKnownPropKeysOf(component);
+  const picked: Partial<PropsOf<T>> = {};
+  for (const key of Object.keys(props) as (keyof PropsOf<T> & string)[]) {
+    if (known.has(key)) {
+      picked[key] = props[key];
+    }
+  }
+  return picked;
+}
+
+/**
+ * Pick only the named keys out of a props object.
+ *
+ * @example
+ * ```tsx
+ * const {fill, stroke} = partialProps(['fill', 'stroke'], props);
+ * ```
+ *
+ * @param keys - The keys to pick.
+ * @param props - The props object to pick from.
+ */
+export function partialProps<T extends object, TKey extends keyof T>(
+  keys: readonly TKey[],
+  props: T,
+): Pick<T, TKey> {
+  const picked = {} as Pick<T, TKey>;
+  for (const key of keys) {
+    if (key in props) {
+      picked[key] = props[key];
+    }
+  }
+  return picked;
+}


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

<!--
Please check these boxes. If a checkbox is not applicable, you can leave it unchecked.
-->

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create one first).
- [x] **Mandatory**: The issue has been accepted (indicated by a [`c-accepted`][label-accepted] label) and is assigned to me.
- [x] **Mandatory**: I have read and understood the [AI policy][ai-policy].
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. I have added an `Assisted-by: <tool name / model>` trailer to the commit message.

## Summary

Warn once per class/prop when a node receives a prop that matches no declared property, a typo or a plugin that isn't registered. Add `pickProps` and `partialProps` to split a merged props object without triggering the warning.

Closes #135.

## Test Plan

<!--
    Describe how this change will be tested.
    You can remove this section if no test changes are needed.
-->

[ai-policy]: https://github.com/canvas-commons/.github/blob/main/AI_POLICY.md
[label-accepted]: https://github.com/canvas-commons/canvas-commons/issues?q=state%3Aopen%20label%3Ac-accepted
