### PR TITLE
fix: media always muted and locked

### DIFF
--- a/packages/2d/src/lib/components/Video.ts
+++ b/packages/2d/src/lib/components/Video.ts
@@ -16,6 +16,57 @@ import {drawImage} from '../utils';
 import {Rect, RectProps} from './Rect';
 import reactivePlaybackRate from './__logs__/reactive-playback-rate';
 
+/**
+ * Forces a video element to stay permanently silent.
+ *
+ * @remarks
+ * Media playback is always muted by design - there is no API to control or
+ * toggle a `Video`'s audio. Besides setting `muted`/`volume`, this also
+ * defends against the element being unmuted later (e.g. by the browser or
+ * pooled reuse) by making `muted` non-writable once locked.
+ */
+const MUTE_LOCKED = Symbol('canvasCommonsMuteLocked');
+
+function silenceVideo(video: HTMLVideoElement): void {
+  const lockable = video as HTMLVideoElement & {[MUTE_LOCKED]?: boolean};
+  if (!lockable[MUTE_LOCKED]) {
+    lockable[MUTE_LOCKED] = true;
+    lockProperty(video, 'muted', true);
+    lockProperty(video, 'volume', 0);
+  }
+
+  video.muted = true;
+  video.volume = 0;
+  video.defaultMuted = true;
+}
+
+/**
+ * Overrides an `HTMLMediaElement` property so it can be read normally but any
+ * attempt to write it is forced back to `forced` - used to make a `Video`'s
+ * audio impossible to turn on.
+ */
+function lockProperty(
+  video: HTMLVideoElement,
+  property: 'muted' | 'volume',
+  forced: boolean | number,
+): void {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLMediaElement.prototype,
+    property,
+  );
+  if (!descriptor?.get || !descriptor.set) {
+    return;
+  }
+
+  const get = descriptor.get.bind(video);
+  const set = descriptor.set.bind(video);
+  Object.defineProperty(video, property, {
+    configurable: true,
+    get,
+    set: () => set(forced),
+  });
+}
+
 export interface VideoProps extends RectProps {
   /**
    * {@inheritDoc Video.src}
@@ -178,6 +229,11 @@ export class Video extends Rect {
       Video.pool[key] = video;
     }
 
+    // Media is always silent - there is intentionally no way to control or
+    // toggle a Video's audio, so enforce muted/volume every time the element
+    // is accessed (playback or a stray unmute could otherwise reset it).
+    silenceVideo(video);
+
     if (video.readyState < 2) {
       DependencyContext.collectPromise(
         new Promise<void>(resolve => {
@@ -228,6 +284,7 @@ export class Video extends Rect {
       this.playing() && time < video.duration && video.playbackRate > 0;
     if (playing) {
       if (video.paused) {
+        silenceVideo(video);
         DependencyContext.collectPromise(video.play());
       }
     } else {

--- a/packages/2d/src/lib/components/__tests__/videoMuted.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/videoMuted.test.tsx
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest';
+import {Video} from '../Video';
+import {mockScene2D} from './mockScene2D';
+
+class TestVideo extends Video {
+  public element(): HTMLVideoElement {
+    return this.video();
+  }
+}
+
+describe('Video muted', () => {
+  mockScene2D();
+
+  it('is muted and silent, and cannot be unmuted', () => {
+    const video = (<TestVideo src="muted-test.mp4" />) as TestVideo;
+    const element = video.element();
+
+    expect(element.muted).toBe(true);
+    expect(element.volume).toBe(0);
+    expect(element.defaultMuted).toBe(true);
+
+    element.muted = false;
+    element.volume = 1;
+    expect(element.muted).toBe(true);
+
+    const reaccessed = video.element();
+    expect(reaccessed).toBe(element);
+    expect(reaccessed.muted).toBe(true);
+    expect(reaccessed.volume).toBe(0);
+  });
+});


### PR DESCRIPTION
## Pre-submission checks

- [x] **Mandatory**: This PR corresponds to an issue (https://github.com/canvas-commons/canvas-commons/issues/147).
- [ ] **Mandatory**: The issue has been accepted (indicated by a [`c-accepted`][label-accepted] label) and is assigned to me.
- [x] **Mandatory**: I have read and understood the [AI policy][ai-policy].
- [ ] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. I have added an `Assisted-by: <tool name / model>` trailer to the commit message.

## Summary

Forces `Video` elements to always be muted and silent. Media playback is always muted by design — there is no API to control or toggle a `Video`'s audio. Besides setting `muted`/`volume`, this also defends against the element being unmuted later (e.g. by the browser or pooled reuse) by making `muted` non-writable once locked via a `MUTE_LOCKED` symbol.

Changes:
- `packages/2d/src/lib/components/Video.ts`: Added `silenceVideo()` and `lockProperty()` helper functions. `silenceVideo()` is called every time the video element is accessed (at creation and at playback) to ensure the audio stays muted. The `lockProperty()` function overrides the `muted` and `volume` setters on `HTMLMediaElement.prototype` to force them back to the muted state.
- `packages/2d/src/lib/components/__tests__/videoMuted.test.tsx`: Added test verifying that a Video element starts muted and silent, and that attempting to unmute or change volume has no effect.

## Test Plan

Run the existing test suite with `pnpm test`. The new `videoMuted` test verifies:
1. The video element starts with `muted=true`, `volume=0`, `defaultMuted=true`
2. Setting `muted=false` and `volume=1` is ignored
3. Re-accessing the element returns the same locked element with audio still muted

[ai-policy]: https://github.com/canvas-commons/.github/blob/main/AI_POLICY.md
[label-accepted]: https://github.com/canvas-commons/canvas-commons/issues?q=state%3Aopen%20label%3Ac-accepted
