### PR TITLE
fix: stabilize playback framerate to match the configured FPS value

### DIFF
--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -339,6 +339,7 @@ export class Player {
    */
   public activate() {
     this.active = true;
+    this.renderTime = 0;
     this.request();
   }
 
@@ -520,8 +521,23 @@ export class Player {
 
     this.requestId ??= requestAnimationFrame(async time => {
       this.requestId = null;
-      if (time - this.renderTime >= 1000 / (this.status.fps + 5)) {
-        this.renderTime = time;
+
+      const framePeriod =
+        1000 / (this.status.fps * Math.max(this.status.speed, 1));
+      if (this.renderTime === 0) this.renderTime = time;
+
+      // Absorbs vsync boundary jitter without skipping a frame
+      const tolerance = framePeriod / 4;
+
+      if (time - this.renderTime >= framePeriod - tolerance) {
+        // Advance by ideal period to avoid drift
+        this.renderTime += framePeriod;
+
+        // Resync after a stall instead of bursting catch-up frames
+        if (time - this.renderTime > framePeriod) {
+          this.renderTime = time;
+        }
+
         await this.lock.acquire();
         try {
           await this.run();

--- a/packages/core/src/app/Presenter.ts
+++ b/packages/core/src/app/Presenter.ts
@@ -110,6 +110,7 @@ export class Presenter {
     this.state.current = PresenterState.Working;
     try {
       this.abortController = new AbortController();
+      this.renderTime = 0;
       await this.run(settings, this.abortController.signal);
     } catch (e: any) {
       this.project.logger.error(e);
@@ -251,8 +252,23 @@ export class Presenter {
 
     this.requestId ??= requestAnimationFrame(async time => {
       this.requestId = null;
-      if (time - this.renderTime >= 1000 / (this.status.fps + 5)) {
-        this.renderTime = time;
+
+      const framePeriod =
+        1000 / (this.status.fps * Math.max(this.status.speed, 1));
+      if (this.renderTime === 0) this.renderTime = time;
+
+      // Absorbs vsync boundary jitter without skipping a frame
+      const tolerance = framePeriod / 4;
+
+      if (time - this.renderTime >= framePeriod - tolerance) {
+        // Advance by ideal period to avoid drift
+        this.renderTime += framePeriod;
+
+        // Resync after a stall instead of bursting catch-up frames
+        if (time - this.renderTime > framePeriod) {
+          this.renderTime = time;
+        }
+
         try {
           await this.loop();
         } catch (e: any) {


### PR DESCRIPTION
## Pre-submission checks

- [x] **Mandatory**: This PR corresponds to an issue (https://github.com/canvas-commons/canvas-commons/issues/151).
- [ ] **Mandatory**: The issue has been accepted (indicated by a [`c-accepted`][label-accepted] label) and is assigned to me.
- [x] **Mandatory**: I have read and understood the [AI policy][ai-policy].
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. I have added an `Assisted-by: <tool name / model>` trailer to the commit message.

## Summary

Stabilizes the playback framerate to be around the configured FPS value. The previous logic used a `>= 1000 / (fps + 5)` check which caused the actual framerate to drift significantly higher than the target, especially at lower FPS settings. It also advanced `renderTime` directly from `time` on every frame, accumulating jitter from `requestAnimationFrame` and vsync boundaries.

Changes (applied identically to both `Player.ts` and `Presenter.ts`):

- **Uses the exact frame period**: Replaces `1000 / (fps + 5)` with `1000 / (fps * max(speed, 1))` for precise period calculation.
- **Adds vsync jitter tolerance**: A tolerance of `framePeriod / 4` absorbs vsync boundary jitter without skipping frames.
- **Advances by ideal period**: `renderTime` is advanced by `+= framePeriod` instead of being set to `time`, preventing long-term drift.
- **Resyncs after stalls**: When a stall longer than one frame period is detected (e.g. tab hidden), `renderTime` resyncs to the current time instead of bursting catch-up frames.
- **Resets on activate**: `renderTime` is set to `0` on `Player.activate()` and at the start of a presentation so the first frame always renders immediately.

## Test Plan

Run the existing test suite with `pnpm test`. The framerate stabilization can be verified by configuring a specific FPS (e.g. 10 FPS) and observing that the actual playback stays around the set value rather than drifting higher.

[ai-policy]: https://github.com/canvas-commons/.github/blob/main/AI_POLICY.md
[label-accepted]: https://github.com/canvas-commons/canvas-commons/issues?q=state%3Aopen%20label%3Ac-accepted
