### PR TITLE
fix(2d): handle tweening while wrapping and newlines better in Txt

### DIFF
--- a/.changeset/kp-hard-breaks.md
+++ b/.changeset/kp-hard-breaks.md
@@ -1,0 +1,6 @@
+---
+'@canvas-commons/2d': patch
+---
+
+Knuth-Plass wrapping treats manual newlines as mandatory breaks instead of
+optional break candidates.

--- a/.changeset/txt-tween-wrap.md
+++ b/.changeset/txt-tween-wrap.md
@@ -1,0 +1,6 @@
+---
+'@canvas-commons/2d': patch
+---
+
+Keep `textWrap` active during text tweens on fixed- and percent-width `Txt`
+nodes.

--- a/packages/2d/src/lib/components/Txt.ts
+++ b/packages/2d/src/lib/components/Txt.ts
@@ -9,10 +9,12 @@ import {
   Vector2,
   all,
   clamp,
+  createSignal,
   threadable,
   tween,
 } from '@canvas-commons/core';
 import {
+  LayoutCursor,
   PreparedTextWithSegments,
   layoutNextLine,
   materializeLineRange,
@@ -31,6 +33,7 @@ import {
   Interval,
   PreparedRichInline,
   RichInlineItem,
+  SOFT_HYPHEN,
   SegmentGranularity,
   buildCanvasFontString,
   carveTextLineSlots,
@@ -349,6 +352,16 @@ type PositionedLine = {
   baselineOffsets: number[];
 };
 
+type LineBreakOffset = {
+  /**
+   * Cut position in the text; content before it (including a terminating
+   * hard break) belongs to the line the cut ends.
+   */
+  offset: number;
+  /** True when the cut breaks a word at a soft hyphen and needs a visible '-'. */
+  hyphen: boolean;
+};
+
 type PreparedLayout =
   | {
       kind: 'rich';
@@ -630,16 +643,72 @@ export class Txt extends Shape {
     const leaf = this.childAs<TxtLeaf>(0);
     if (!leaf) return;
 
-    // Suppress wrapping while the box tweens between text sizes.
     const oldWrap = this.textWrap.context.raw();
-    this.textWrap(false);
+    const desiredWidth = this.width.context.getter();
+    const explicitWidth = typeof desiredWidth === 'number';
+    let wrapWidth: number | null = explicitWidth ? desiredWidth : null;
+    if (
+      wrapWidth === null &&
+      desiredWidth !== null &&
+      this.textWrap() !== false
+    ) {
+      const computedWidth = this.computedSize().x;
+      if (computedWidth > 0) {
+        // The +0.5 absorbs yoga's pixel rounding, mirroring effectiveMaxWidth.
+        wrapWidth = computedWidth + 0.5;
+      }
+    }
+    const keepWrap = this.textWrap() !== false && wrapWidth !== null;
+    if (!keepWrap) {
+      this.textWrap(false);
+    }
 
     const oldText = leaf.text.context.raw();
+    const fromText = leaf.text();
     const oldSizeRaw = this.size.context.raw();
     const oldSize = new Vector2(this.size());
+
+    // Pre-measure both endpoint layouts so the in-flight string can reuse
+    // their line breaks instead of re-wrapping every frame. A path never
+    // wraps, surrogate pairs would desync the code-unit offsets from
+    // textLerp's code-point composition, and lineBreakOffsets bails on
+    // layouts whose offsets cannot be mapped back to the raw text.
+    const surrogates = /[\uD800-\uDFFF]/;
+    let fromBreaks: LineBreakOffset[] | null = null;
+    if (
+      keepWrap &&
+      wrapWidth !== null &&
+      !this.textPath() &&
+      !surrogates.test(fromText)
+    ) {
+      fromBreaks = this.lineBreakOffsets(fromText, wrapWidth);
+    }
+
     leaf.text(value);
+    const toText = leaf.text();
+    let toBreaks: LineBreakOffset[] | null = null;
+    if (fromBreaks !== null && wrapWidth !== null && !surrogates.test(toText)) {
+      toBreaks = this.lineBreakOffsets(toText, wrapWidth);
+    }
     const newSize = new Vector2(this.size());
     leaf.text(oldText ?? DEFAULT);
+
+    let interpolate: InterpolationFunction<string> = interpolationFunction;
+    let lastRaw: string | null = null;
+    if (fromBreaks !== null && toBreaks !== null) {
+      const stableFrom = fromBreaks;
+      const stableTo = toBreaks;
+      interpolate = (from, to, t) => {
+        const raw = interpolationFunction(from, to, t);
+        lastRaw = raw;
+        // A reactive tween target is re-resolved every frame; the measured
+        // offsets only describe the endpoints captured above.
+        if (from !== fromText || to !== toText) {
+          return raw;
+        }
+        return Txt.stabilizeBreaks(raw, from, to, stableFrom, stableTo);
+      };
+    }
 
     if (oldSize.y === 0) {
       this.height(newSize.y);
@@ -656,23 +725,163 @@ export class Txt extends Shape {
     };
 
     this.lockLayout();
+    if (fromBreaks !== null && toBreaks !== null) {
+      this.forcedBreaksOnly(true);
+      this.tweenTargetLines(
+        Txt.stabilizeBreaks(
+          toText,
+          fromText,
+          toText,
+          fromBreaks,
+          toBreaks,
+        ).split('\n'),
+      );
+    }
 
-    yield* all(
-      tween(time, t => {
-        const progress = timingFunction(t);
-        this.size(Vector2.lerp(sizeAt(oldSize), sizeAt(newSize), progress));
-      }),
-      leaf.text(value, time, timingFunction, interpolationFunction),
-    );
+    let completed = false;
+    try {
+      yield* all(
+        tween(time, t => {
+          const progress = timingFunction(t);
+          const size = Vector2.lerp(sizeAt(oldSize), sizeAt(newSize), progress);
+          // A wrapped percent width stays container-driven, so only the
+          // height animates; otherwise the box lerps between text sizes.
+          if (keepWrap && !explicitWidth) {
+            this.height(size.y);
+          } else {
+            this.size(size);
+          }
+        }),
+        leaf.text(value, time, timingFunction, interpolate),
+      );
 
-    this.children.context.setter(value);
-    this.releaseLayout();
-    this.textWrap(oldWrap ?? DEFAULT);
-    this.size(oldSizeRaw);
+      this.children.context.setter(value);
+      completed = true;
+    } finally {
+      // Don't leave tweens in a broken state
+      if (!completed && lastRaw !== null) {
+        leaf.text(lastRaw);
+      }
+      this.forcedBreaksOnly(false);
+      this.tweenTargetLines(null);
+      this.releaseLayout();
+      this.textWrap(oldWrap ?? DEFAULT);
+      this.size(oldSizeRaw);
+    }
   }
 
   protected getLayout(): boolean {
     return true;
+  }
+
+  private static cursorOffset(
+    segments: readonly string[],
+    cursor: LayoutCursor,
+  ): number {
+    let offset = 0;
+    for (let i = 0; i < cursor.segmentIndex; i++) {
+      offset += segments[i].length;
+    }
+    if (cursor.graphemeIndex > 0) {
+      let remaining = cursor.graphemeIndex;
+      for (const g of segment(segments[cursor.segmentIndex], 'grapheme')) {
+        if (remaining === 0) break;
+        offset += g.segment.length;
+        remaining--;
+      }
+    }
+    return offset;
+  }
+
+  private lineBreakOffsets(
+    source: string,
+    maxWidth: number,
+  ): LineBreakOffset[] | null {
+    const prepared = this.preparedLayout();
+    if (!prepared || prepared.kind !== 'simple') return null;
+    const segments = prepared.prepared.segments;
+    const preparedSource = segments.join('');
+
+    const hyphenated = this.hyphenate() !== null;
+    if (hyphenated) {
+      if (preparedSource.replaceAll(SOFT_HYPHEN, '') !== source) return null;
+    } else if (preparedSource !== source) {
+      return null;
+    }
+
+    const {ends} = this.layoutSimple(
+      prepared.prepared,
+      prepared.style,
+      maxWidth,
+    );
+
+    const breaks: LineBreakOffset[] = [];
+    for (let i = 0; i < ends.length - 1; i++) {
+      const cursor = ends[i];
+      let offset = Txt.cursorOffset(segments, cursor);
+      const hyphen =
+        cursor.graphemeIndex === 0 &&
+        cursor.segmentIndex > 0 &&
+        segments[cursor.segmentIndex - 1] === SOFT_HYPHEN;
+      if (hyphenated) {
+        let shyCount = 0;
+        for (let j = 0; j < offset; j++) {
+          if (preparedSource[j] === SOFT_HYPHEN) shyCount++;
+        }
+        offset -= shyCount;
+      }
+      breaks.push({offset, hyphen});
+    }
+    return breaks;
+  }
+
+  private static commonPrefixLength(a: string, b: string): number {
+    let length = 0;
+    const max = Math.min(a.length, b.length);
+    while (length < max && a[length] === b[length]) {
+      length++;
+    }
+    return length;
+  }
+
+  private static stabilizeBreaks(
+    text: string,
+    source: string,
+    target: string,
+    fromBreaks: LineBreakOffset[],
+    toBreaks: LineBreakOffset[],
+  ): string {
+    const typedTo = Txt.commonPrefixLength(text, target);
+    const typedFrom = Txt.commonPrefixLength(text, source);
+    const merged =
+      typedTo >= typedFrom
+        ? [
+            ...toBreaks.filter(b => b.offset <= typedTo),
+            ...fromBreaks.filter(b => b.offset > typedTo),
+          ]
+        : [
+            ...fromBreaks.filter(b => b.offset <= typedFrom),
+            ...toBreaks.filter(b => b.offset > typedFrom),
+            ...fromBreaks.filter(
+              b => b.offset > Math.max(typedFrom, target.length),
+            ),
+          ];
+
+    let result = '';
+    let prev = 0;
+    for (const brk of merged) {
+      if (brk.offset <= prev || brk.offset >= text.length) {
+        continue;
+      }
+      const slice = text.slice(prev, brk.offset);
+      result += brk.hyphen
+        ? slice + '-\n'
+        : slice.endsWith('\n')
+          ? slice
+          : slice + '\n';
+      prev = brk.offset;
+    }
+    return result + text.slice(prev);
   }
 
   public constructor({children, text, ...props}: TxtProps) {
@@ -973,13 +1182,20 @@ export class Txt extends Shape {
     prepared: PreparedTextWithSegments,
     maxWidth: number,
     exclusions: TextExclusion[],
-  ): {text: string; x: number; width: number; lineTop: number}[] {
+  ): {
+    text: string;
+    x: number;
+    width: number;
+    lineTop: number;
+    end: LayoutCursor;
+  }[] {
     const lh = this.resolvedLineHeight();
     const lines: {
       text: string;
       x: number;
       width: number;
       lineTop: number;
+      end: LayoutCursor;
     }[] = [];
     let cursor = {segmentIndex: 0, graphemeIndex: 0};
     let lineTop = 0;
@@ -1041,6 +1257,7 @@ export class Txt extends Shape {
         x: slot.left,
         width: line.width,
         lineTop,
+        end: line.end,
       });
       cursor = line.end;
       lineTop += lh;
@@ -1164,6 +1381,73 @@ export class Txt extends Shape {
   };
 
   /**
+   * Lay out a simple (single-style) prepared text, dispatching between the
+   * three wrapping strategies: exclusion bands, Knuth-Plass, and pretext's
+   * greedy walker. Single source of truth for that dispatch — the per-line
+   * `ends` cursors feed {@link lineBreakOffsets}, so tween break
+   * stabilization always matches what {@link layoutFor} renders.
+   */
+  private layoutSimple(
+    prepared: PreparedTextWithSegments,
+    style: FragmentStyle,
+    maxWidth: number,
+  ): {lines: TextLine[]; ends: LayoutCursor[]; width: number} {
+    const lineHeight = this.resolvedLineHeight();
+    const lines: TextLine[] = [];
+    const ends: LayoutCursor[] = [];
+    let width = 0;
+
+    const exclusions = this.exclusions();
+    if (exclusions.length > 0 && Number.isFinite(maxWidth)) {
+      const bandLines = this.layoutWithExclusions(
+        prepared,
+        maxWidth,
+        exclusions,
+      );
+      for (const line of bandLines) {
+        lines.push({
+          fragments: [{text: line.text, x: line.x, style}],
+          top: line.lineTop,
+          height: lineHeight,
+        });
+        ends.push(line.end);
+        const fullRight = line.x + line.width;
+        if (fullRight > width) width = fullRight;
+      }
+    } else if (this.wrapMode() === 'knuth-plass') {
+      const {normalSpaceWidth, hyphenWidth} = this.measureFontConstants(
+        style.font,
+      );
+      const kpLines = knuthPlass(prepared, maxWidth, {
+        normalSpaceWidth,
+        hyphenWidth,
+      });
+      for (const line of kpLines) {
+        lines.push({
+          fragments: [{text: line.text, x: 0, style}],
+          top: lines.length * lineHeight,
+          height: lineHeight,
+        });
+        ends.push({segmentIndex: line.endSegmentIndex, graphemeIndex: 0});
+        if (line.width > width) width = line.width;
+      }
+    } else {
+      walkLineRanges(prepared, maxWidth, range => {
+        const line = materializeLineRange(prepared, range);
+        lines.push({
+          fragments: [{text: line.text, x: 0, style}],
+          top: lines.length * lineHeight,
+          height: lineHeight,
+        });
+        ends.push(range.end);
+        if (line.width > width) width = line.width;
+      });
+    }
+
+    return {lines, ends, width};
+  }
+
+  /**
    * Compute the text layout for an explicit max-width. Used by the yoga
    * measure function (which receives the constraint dynamically) and by
    * draw() / public introspection methods (which read the resolved size).
@@ -1173,121 +1457,77 @@ export class Txt extends Shape {
     if (!prepared) return Txt.emptyLayout;
 
     const baseLineHeight = this.resolvedLineHeight();
-    const fragmentLines: StyledFragment[][] = [];
-    let totalWidth = 0;
 
-    // A tall inline element grows only its own line's box, CSS-style.
-    const finish = (): TextLayoutResult => {
-      const lines: TextLine[] = [];
-      let top = 0;
-      for (const fragments of fragmentLines) {
-        let height = baseLineHeight;
-        for (const frag of fragments) {
-          if (frag.inline) {
-            const inlineHeight = frag.inline.size.y();
-            if (inlineHeight > height) height = inlineHeight;
-          }
-        }
-        lines.push({fragments, top, height});
-        top += height;
-      }
-      return {
-        lines,
-        width: totalWidth,
-        height: top,
-        lineHeight: baseLineHeight,
-      };
-    };
-
-    const exclusions = this.exclusions();
-    if (
-      exclusions.length > 0 &&
-      prepared.kind === 'simple' &&
-      Number.isFinite(maxWidth)
-    ) {
-      const bandLines = this.layoutWithExclusions(
+    if (prepared.kind === 'simple') {
+      const {lines, width} = this.layoutSimple(
         prepared.prepared,
+        prepared.style,
         maxWidth,
-        exclusions,
       );
-      const lines: TextLine[] = [];
-      for (const line of bandLines) {
-        lines.push({
-          fragments: [{text: line.text, x: line.x, style: prepared.style}],
-          top: line.lineTop,
-          height: baseLineHeight,
-        });
-        const fullRight = line.x + line.width;
-        if (fullRight > totalWidth) totalWidth = fullRight;
-      }
       const lastLine = lines[lines.length - 1];
       return {
         lines,
-        width: totalWidth,
+        width,
         height: lastLine ? lastLine.top + lastLine.height : 0,
         lineHeight: baseLineHeight,
       };
     }
 
-    if (prepared.kind === 'simple' && this.wrapMode() === 'knuth-plass') {
-      const {normalSpaceWidth, hyphenWidth} = this.measureFontConstants(
-        prepared.style.font,
-      );
-      const kpLines = knuthPlass(prepared.prepared, maxWidth, {
-        normalSpaceWidth,
-        hyphenWidth,
-      });
-      for (const line of kpLines) {
-        fragmentLines.push([{text: line.text, x: 0, style: prepared.style}]);
-        if (line.width > totalWidth) totalWidth = line.width;
+    const fragmentLines: StyledFragment[][] = [];
+    let totalWidth = 0;
+    for (const group of prepared.groups) {
+      if (group.prepared === null) {
+        fragmentLines.push([]);
+        continue;
       }
-      return finish();
-    }
-
-    if (prepared.kind === 'rich') {
-      for (const group of prepared.groups) {
-        if (group.prepared === null) {
-          fragmentLines.push([]);
-          continue;
+      const groupPrepared = group.prepared;
+      walkRichInlineLineRanges(groupPrepared, maxWidth, range => {
+        const line = materializeRichInlineLineRange(groupPrepared, range);
+        const styledFragments: StyledFragment[] = [];
+        let x = 0;
+        for (const fragment of line.fragments) {
+          x += fragment.gapBefore;
+          const originalIndex = group.itemMap[fragment.itemIndex];
+          const style = prepared.styles[originalIndex];
+          const inline = prepared.inlines[originalIndex] ?? undefined;
+          if (style) {
+            styledFragments.push({
+              text: fragment.text,
+              x,
+              style,
+              inline,
+              inlineWidth: inline ? fragment.occupiedWidth : undefined,
+            });
+          }
+          x += fragment.occupiedWidth;
         }
-        const groupPrepared = group.prepared;
-        walkRichInlineLineRanges(groupPrepared, maxWidth, range => {
-          const line = materializeRichInlineLineRange(groupPrepared, range);
-          const styledFragments: StyledFragment[] = [];
-          let x = 0;
-          for (const fragment of line.fragments) {
-            x += fragment.gapBefore;
-            const originalIndex = group.itemMap[fragment.itemIndex];
-            const style = prepared.styles[originalIndex];
-            const inline = prepared.inlines[originalIndex] ?? undefined;
-            if (style) {
-              styledFragments.push({
-                text: fragment.text,
-                x,
-                style,
-                inline,
-                inlineWidth: inline ? fragment.occupiedWidth : undefined,
-              });
-            }
-            x += fragment.occupiedWidth;
-          }
-          fragmentLines.push(styledFragments);
-          if (line.width > totalWidth) {
-            totalWidth = line.width;
-          }
-        });
-      }
-    } else {
-      walkLineRanges(prepared.prepared, maxWidth, range => {
-        const line = materializeLineRange(prepared.prepared, range);
-        fragmentLines.push([{text: line.text, x: 0, style: prepared.style}]);
+        fragmentLines.push(styledFragments);
         if (line.width > totalWidth) {
           totalWidth = line.width;
         }
       });
     }
 
-    return finish();
+    // A tall inline element grows only its own line's box, CSS-style.
+    const lines: TextLine[] = [];
+    let top = 0;
+    for (const fragments of fragmentLines) {
+      let height = baseLineHeight;
+      for (const frag of fragments) {
+        if (frag.inline) {
+          const inlineHeight = frag.inline.size.y();
+          if (inlineHeight > height) height = inlineHeight;
+        }
+      }
+      lines.push({fragments, top, height});
+      top += height;
+    }
+    return {
+      lines,
+      width: totalWidth,
+      height: top,
+      lineHeight: baseLineHeight,
+    };
   }
 
   /**
@@ -1376,12 +1616,33 @@ export class Txt extends Shape {
   }
 
   /**
+   * While a stabilized text tween is running, every line break is forced into
+   * the leaf text, so soft wrapping has nothing left to do. Turning it off
+   * also keeps lines that rely on pretext's hyphen overhang (a discretionary
+   * hyphen is not counted against the wrap width) from being re-broken once
+   * the hyphen is materialized as a literal '-'.
+   */
+  private readonly forcedBreaksOnly = createSignal(false);
+
+  /**
+   * Per-line target text of the stabilized tween in flight. Lets justify
+   * render the still-typing line with its final spacing instead of ragged
+   * natural width.
+   */
+  private readonly tweenTargetLines = createSignal<string[] | null>(null);
+
+  /**
    * Effective wrap constraint when no explicit yoga measurement is in play
    * (e.g. for `draw()` and `textLines()`).
    */
   @computed()
   protected effectiveMaxWidth(): number {
     if (this.pathProfile() || this.textWrap() === false) {
+      return Number.POSITIVE_INFINITY;
+    }
+    // Exclusions still need the finite width: their per-band x offsets are
+    // carved from it, so forced-break layouts keep flowing around them.
+    if (this.forcedBreaksOnly() && this.exclusions().length === 0) {
       return Number.POSITIVE_INFINITY;
     }
     const desiredWidth = this.width.context.getter();
@@ -1504,8 +1765,34 @@ export class Txt extends Shape {
         );
       }
 
+      // During a stabilized tween every line's final content is known, so
+      // the still-typing line can borrow its target's justify spacing —
+      // words land at their settled positions, and an overfull Knuth-Plass
+      // line never pokes past the block while incomplete.
+      let finalText: string | null = null;
+      if (align === 'justify' && isLastLine && line.fragments.length === 1) {
+        const targetLines = this.tweenTargetLines();
+        if (targetLines !== null && i < targetLines.length - 1) {
+          const target =
+            this.wrapMode() === 'knuth-plass'
+              ? targetLines[i].replace(/\s+$/, '')
+              : targetLines[i];
+          if (target.startsWith(line.fragments[0].text)) {
+            finalText = target;
+          }
+        }
+      }
+
+      // Knuth-Plass plans lines whose spaces compress below their natural
+      // width, so justify must also squeeze overfull lines there; greedy
+      // never plans compression (an overfull greedy line is hyphen overhang
+      // or an in-flight tween seam, both drawn at natural width).
       const justifyLine =
-        align === 'justify' && !isLastLine && lineWidth < blockWidth;
+        align === 'justify' &&
+        (!isLastLine || finalText !== null) &&
+        (finalText !== null ||
+          lineWidth < blockWidth ||
+          (lineWidth > blockWidth && this.wrapMode() === 'knuth-plass'));
       let extraPerSpace = 0;
       let justified: JustifiedSegment[][] | null = null;
       if (justifyLine) {
@@ -1525,7 +1812,22 @@ export class Txt extends Shape {
           }
           return segments;
         });
-        if (spaceCount > 0) {
+        if (finalText !== null) {
+          let finalSpaceCount = 0;
+          for (const seg of segment(finalText, 'word')) {
+            if (!seg.isWordLike && /^\s+$/.test(seg.segment)) {
+              finalSpaceCount++;
+            }
+          }
+          if (finalSpaceCount > 0) {
+            extraPerSpace =
+              (blockWidth -
+                this.measureStyledText(finalText, line.fragments[0].style)) /
+              finalSpaceCount;
+          } else {
+            justified = null;
+          }
+        } else if (spaceCount > 0) {
           extraPerSpace = (blockWidth - lineWidth) / spaceCount;
         } else {
           justified = null;
@@ -1546,7 +1848,7 @@ export class Txt extends Shape {
           ? 0
           : this.computeAlignOffset(blockWidth, lineWidth),
         extraPerSpace,
-        justified: extraPerSpace > 0 ? justified : null,
+        justified: extraPerSpace !== 0 ? justified : null,
         baselineOffsets,
       });
     }
@@ -1599,7 +1901,7 @@ export class Txt extends Shape {
         context.lineWidth = style.lineWidth;
 
         const justified = line.justified?.[fragIndex];
-        if (justified && line.extraPerSpace > 0) {
+        if (justified && line.extraPerSpace !== 0) {
           let cursorX = x;
           for (const seg of justified) {
             if (!seg.whitespace) {
@@ -1949,7 +2251,11 @@ export class Txt extends Shape {
         if (fragment.inline) continue;
         const fragLeft = fragment.x + line.alignOffset - blockWidth / 2;
         const justified = line.justified?.[f];
-        if (justified && line.extraPerSpace > 0 && granularity !== 'sentence') {
+        if (
+          justified &&
+          line.extraPerSpace !== 0 &&
+          granularity !== 'sentence'
+        ) {
           // Match the word-by-word paint; a whole-fragment measure re-adds the
           // inter-word kerning the paint omits.
           let cursor = fragLeft;

--- a/packages/2d/src/lib/components/__tests__/hyphenBoundary.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/hyphenBoundary.test.tsx
@@ -1,0 +1,72 @@
+import {waitFor} from '@canvas-commons/core';
+import {describe, expect, it} from 'vitest';
+import {Txt} from '../Txt';
+import {generatorTest} from './generatorTest';
+import {mockScene2D} from './mockScene2D';
+import {mockTextContext} from './mockTextContext';
+
+function charWidth(ch: string): number {
+  if (ch === '­') return 0;
+  return 6 + ((ch.codePointAt(0) ?? 0) % 7);
+}
+
+function measure(text: string): number {
+  let width = 0;
+  for (const ch of text) width += charWidth(ch);
+  return width;
+}
+
+function hyphenateWord(word: string): string[] {
+  if (word.length <= 6) return [word];
+  const parts: string[] = [];
+  for (let i = 0; i < word.length; i += 4) {
+    parts.push(word.slice(i, i + 4));
+  }
+  return parts;
+}
+
+function lineTexts(txt: Txt): string[] {
+  return txt
+    .textLines()
+    .lines.map(line => line.fragments.map(f => f.text).join(''));
+}
+
+describe('hyphenated tween completion boundary', () => {
+  mockScene2D();
+  mockTextContext(measure);
+
+  it(
+    'settles to the same lines the final tween frame showed',
+    generatorTest(function* () {
+      const txt = (
+        <Txt
+          width={300}
+          textWrap
+          text={'The old druid grins at you.\n"Storms have passed," she says.'}
+        />
+      ) as Txt;
+
+      txt.hyphenate(() => hyphenateWord);
+      yield* txt.width(180, 0.8);
+
+      const frames: string[][] = [];
+      yield txt.text(
+        'Her uncharacteristically overcomplicated topographical switchback.',
+        2,
+      );
+      yield* waitFor(1.9);
+      for (let i = 0; i < 12; i++) {
+        frames.push(lineTexts(txt));
+        yield;
+      }
+
+      // 'Her uncharacteristic' measures exactly the wrap width, so this break
+      // only fits via hyphen overhang — it must hold across the boundary.
+      const settled = frames[frames.length - 1];
+      expect(settled[0]).toBe('Her uncharacteristic-');
+      for (const lines of frames) {
+        expect(lines).toEqual(settled);
+      }
+    }),
+  );
+});

--- a/packages/2d/src/lib/components/__tests__/knuthPlass.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/knuthPlass.test.tsx
@@ -1,7 +1,10 @@
+import {linear, waitFor} from '@canvas-commons/core';
 import {describe, expect, it} from 'vitest';
 import {knuthPlass} from '../../text/knuthPlass';
 import {Txt} from '../Txt';
+import {generatorTest} from './generatorTest';
 import {mockScene2D} from './mockScene2D';
+import {mockTextContext} from './mockTextContext';
 
 function fakePrepared(segments: string[], widths: number[]) {
   // The Knuth-Plass implementation reads only `.segments` and `.widths`. We
@@ -69,6 +72,44 @@ describe('knuthPlass', () => {
     expect(lines[0].text.endsWith('-')).toBe(true);
   });
 
+  it('treats manual newlines as mandatory breaks', () => {
+    const prepared = fakePrepared(
+      ['aa', '\n', 'bb', ' ', 'cc'],
+      [20, 0, 20, 4, 20],
+    );
+    const lines = knuthPlass(prepared, 200, {
+      normalSpaceWidth: 4,
+      hyphenWidth: 3,
+    });
+
+    expect(lines.map(l => l.text)).toEqual(['aa', 'bb cc']);
+    expect(lines[0].endSegmentIndex).toBe(2);
+    expect(lines[0].isLast).toBe(false);
+    expect(lines[1].isLast).toBe(true);
+  });
+
+  it('emits a blank line for consecutive newlines', () => {
+    const prepared = fakePrepared(['aa', '\n', '\n', 'bb'], [20, 0, 0, 20]);
+    const lines = knuthPlass(prepared, 200, {
+      normalSpaceWidth: 4,
+      hyphenWidth: 3,
+    });
+
+    expect(lines.map(l => l.text)).toEqual(['aa', '', 'bb']);
+  });
+
+  it('folds a trailing newline into the final line', () => {
+    const prepared = fakePrepared(['aa', '\n'], [20, 0]);
+    const lines = knuthPlass(prepared, 200, {
+      normalSpaceWidth: 4,
+      hyphenWidth: 3,
+    });
+
+    expect(lines.map(l => l.text)).toEqual(['aa']);
+    expect(lines[0].isLast).toBe(true);
+    expect(lines[0].endSegmentIndex).toBe(2);
+  });
+
   it('handles empty input', () => {
     const lines = knuthPlass(fakePrepared([], []), 100, {
       normalSpaceWidth: 4,
@@ -76,6 +117,56 @@ describe('knuthPlass', () => {
     });
     expect(lines).toEqual([]);
   });
+});
+
+class JustifyProbe extends Txt {
+  public probeLines() {
+    return this.positionedLines();
+  }
+}
+
+describe('Txt knuth-plass justify', () => {
+  mockScene2D();
+  mockTextContext();
+
+  it('compresses spaces on lines Knuth-Plass planned overfull', () => {
+    const txt = new JustifyProbe({
+      width: 100,
+      textWrap: true,
+      wrapMode: 'knuth-plass',
+      textAlign: 'justify',
+      text: 'aa bb cc dd ee ff gg hh',
+    });
+
+    // KP picks 'aa bb cc dd' (natural 110 > 100) over the badly stretched
+    // three-word split; justify must squeeze its three spaces to fit.
+    const lines = txt.probeLines();
+    expect(lines[0].justified).not.toBeNull();
+    expect(lines[0].extraPerSpace).toBeCloseTo(-10 / 3);
+  });
+
+  it(
+    'justifies the typing line with its final spacing mid-tween',
+    generatorTest(function* () {
+      const txt = new JustifyProbe({
+        width: 100,
+        textWrap: true,
+        wrapMode: 'knuth-plass',
+        textAlign: 'justify',
+        text: '',
+      });
+
+      yield txt.text('aa bb cc dd ee ff gg hh', 2, linear);
+      yield* waitFor(0.9);
+
+      // Only 'aa bb cc d' is typed, but the line already uses the finished
+      // line's compressed spacing, so it can never overflow the block.
+      const lines = txt.probeLines();
+      expect(lines).toHaveLength(1);
+      expect(lines[0].justified).not.toBeNull();
+      expect(lines[0].extraPerSpace).toBeCloseTo(-10 / 3);
+    }),
+  );
 });
 
 describe('Txt wrapMode + hyphenate', () => {

--- a/packages/2d/src/lib/components/__tests__/mockTextContext.ts
+++ b/packages/2d/src/lib/components/__tests__/mockTextContext.ts
@@ -2,12 +2,19 @@ import {afterAll, beforeAll} from 'vitest';
 
 /**
  * Install a deterministic fake 2D context for the suite so text geometry is
- * reproducible without a real canvas: every glyph measures `charWidth` pixels,
+ * reproducible without a real canvas: glyph widths come from `charWidth`,
  * and the paint calls are no-ops. Restores the original `getContext` afterwards.
  *
- * @param charWidth - Width reported per character by `measureText`.
+ * @param charWidth - Width reported per character by `measureText`, or a
+ *   function measuring a whole string for per-character widths.
  */
-export function mockTextContext(charWidth = 10): void {
+export function mockTextContext(
+  charWidth: number | ((text: string) => number) = 10,
+): void {
+  const measure =
+    typeof charWidth === 'number'
+      ? (text: string) => text.length * charWidth
+      : charWidth;
   let original: typeof HTMLCanvasElement.prototype.getContext;
   beforeAll(() => {
     original = HTMLCanvasElement.prototype.getContext;
@@ -26,7 +33,7 @@ export function mockTextContext(charWidth = 10): void {
       restore() {},
       setLineDash() {},
       measureText(text: string) {
-        return {width: text.length * charWidth} as TextMetrics;
+        return {width: measure(text)} as TextMetrics;
       },
       fillText() {},
       strokeText() {},

--- a/packages/2d/src/lib/components/__tests__/textWrapTween.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/textWrapTween.test.tsx
@@ -1,0 +1,274 @@
+import {cancel, linear, waitFor} from '@canvas-commons/core';
+import {describe, expect, it} from 'vitest';
+import {Layout} from '../Layout';
+import {Txt} from '../Txt';
+import {generatorTest} from './generatorTest';
+import {mockScene2D} from './mockScene2D';
+import {mockTextContext} from './mockTextContext';
+
+function lineTexts(txt: Txt): string[] {
+  return txt
+    .textLines()
+    .lines.map(line => line.fragments.map(f => f.text).join(''));
+}
+
+// Width 100 at 10px per mocked glyph gives 10 characters per line, so the
+// expected line sets below are exact.
+describe('Txt textWrap during text tweens', () => {
+  mockScene2D();
+  mockTextContext();
+
+  it(
+    'keeps wrapping a fixed-width Txt mid-tween',
+    generatorTest(function* () {
+      const txt = (
+        <Txt width={100} textWrap>
+          aaaa bbbb cccc dddd eeee ffff
+        </Txt>
+      ) as Txt;
+
+      yield txt.text('gggg hhhh iiii jjjj kkkk llll', 2, linear);
+      yield* waitFor(1);
+
+      expect(txt.textWrap()).toBe(true);
+      expect(txt.textLines().lines.length).toBeGreaterThan(1);
+    }),
+  );
+
+  it(
+    'restores textWrap when the tween is cancelled',
+    generatorTest(function* () {
+      const txt = (
+        <Txt width={100} textWrap>
+          aaaa bbbb cccc dddd eeee ffff
+        </Txt>
+      ) as Txt;
+
+      const task = yield txt.text('gggg hhhh iiii jjjj kkkk llll', 2, linear);
+      yield* waitFor(1);
+      cancel(task);
+
+      expect(txt.textWrap()).toBe(true);
+      // Cancellation restores the plain interpolated value — endpoint
+      // characters only, no injected breaks — and the configured width.
+      expect(txt.text()).toBe('gggg hhhh iiii dddd eeee ffff');
+      expect(txt.width()).toBe(100);
+    }),
+  );
+
+  it(
+    'uses the target breaks while a shrinking tween types over the source',
+    generatorTest(function* () {
+      const txt = (
+        <Txt width={100} textWrap text={'xx yy zz www vvv uuu'} />
+      ) as Txt;
+
+      yield txt.text('aaaa bbbb cccc', 2, linear);
+      yield* waitFor(1.7);
+
+      // textLerp's shrinking branch keeps the source head and writes target
+      // characters behind it; the typed region must break at the target's
+      // offset (10), not the source's (9).
+      expect(lineTexts(txt)).toEqual(['xx a bbbb ', 'ccccv']);
+    }),
+  );
+
+  it(
+    'holds settled lines steady while the tail still shows old text',
+    generatorTest(function* () {
+      const txt = (
+        <Txt width={100} textWrap text={'aa bb cc dd ee ff gg hh'} />
+      ) as Txt;
+
+      yield txt.text('aaaaaa bb cc dd ee ff g', 2, linear);
+      yield* waitFor(1);
+
+      // The typed head wraps like the new text, the remaining tail keeps the
+      // old text's breaks — 'gg hh' must not hop up a line mid-tween.
+      expect(lineTexts(txt)).toEqual(['aaaaaa bb ', 'c ee ff ', 'gg hh']);
+    }),
+  );
+
+  it(
+    'reveals typewriter text along the final line breaks',
+    generatorTest(function* () {
+      const txt = (<Txt width={100} textWrap text={''} />) as Txt;
+
+      yield txt.text('aaaa bbbb cccc dddd', 2, linear);
+      yield* waitFor(1);
+
+      expect(lineTexts(txt)).toEqual(['aaaa bbbb']);
+    }),
+  );
+
+  it(
+    'respects manual newlines mid-tween',
+    generatorTest(function* () {
+      const txt = (
+        <Txt width={100} textWrap text={'aaaa\nbb cc dd ee'} />
+      ) as Txt;
+
+      yield txt.text('aaaa\nff gg hh ii', 2, linear);
+      yield* waitFor(1);
+
+      expect(lineTexts(txt)).toEqual(['aaaa', 'ff cc dd ', 'ee']);
+    }),
+  );
+
+  it(
+    'keeps the visible hyphen at a soft-hyphen break mid-tween',
+    generatorTest(function* () {
+      const hyphenator = (word: string): string[] =>
+        word.length > 3 ? [word.slice(0, 3), word.slice(3)] : [word];
+      const txt = (
+        <Txt width={40} textWrap hyphenate={() => hyphenator} text={'abcdef'} />
+      ) as Txt;
+
+      yield txt.text('abcxyz', 2, linear);
+      yield* waitFor(1);
+
+      expect(txt.text()).toBe('abc-\ndef');
+      expect(lineTexts(txt)).toEqual(['abc-', 'def']);
+    }),
+  );
+
+  it(
+    'keeps lines stable around exclusions mid-tween',
+    generatorTest(function* () {
+      const txt = (
+        <Txt
+          width={150}
+          textWrap
+          fontSize={20}
+          lineHeight={20}
+          exclusions={[{kind: 'rect', x: 0, y: 0, width: 50, height: 30}]}
+          text={'aa bb cc dd ee ff gg hh'}
+        />
+      ) as Txt;
+
+      yield txt.text('aaaaaa bb cc dd ee ff g', 2, linear);
+      yield* waitFor(1);
+
+      const layout = txt.textLines();
+      const texts = layout.lines.map(l =>
+        l.fragments.map(f => f.text).join(''),
+      );
+      // Lines 1-2 sit beside the exclusion (x = 50, 10 chars wide), line 3
+      // clears it — 'gg hh' must stay on its own line instead of refilling.
+      expect(texts).toEqual(['aaaaaa bb ', 'c ee ff ', 'gg hh']);
+      expect(layout.lines.map(l => l.fragments[0].x)).toEqual([50, 50, 0]);
+    }),
+  );
+
+  it(
+    'holds Knuth-Plass lines steady mid-tween',
+    generatorTest(function* () {
+      const txt = (
+        <Txt
+          width={100}
+          textWrap
+          wrapMode={'knuth-plass'}
+          text={'aaaa bbbb cccc'}
+        />
+      ) as Txt;
+
+      yield txt.text('dddd eeee ffff', 2, linear);
+      yield* waitFor(1);
+
+      expect(txt.text()).toBe('dddd ebbb \ncccc');
+      expect(lineTexts(txt)).toEqual(['dddd ebbb', 'cccc']);
+    }),
+  );
+
+  it(
+    'keeps wrapping a percent-width Txt mid-tween',
+    generatorTest(function* (view) {
+      const txt = (<Txt textWrap width={'80%'} text={''} />) as Txt;
+      view.add(txt);
+
+      yield txt.text('word '.repeat(64).trimEnd(), 2, linear);
+      yield* waitFor(1);
+
+      // 80% of the 1920 view resolves to 1536px — 153 mocked glyphs per line.
+      expect(txt.textWrap()).toBe(true);
+      expect(txt.textLines().lines.length).toBeGreaterThan(1);
+    }),
+  );
+
+  it(
+    'holds lines steady for a percent-width Txt inside a layout',
+    generatorTest(function* (view) {
+      const txt = (
+        <Txt textWrap width={'100%'} text={'aa bb cc dd ee ff gg hh'} />
+      ) as Txt;
+      view.add(
+        <Layout layout width={100} height={400}>
+          {txt}
+        </Layout>,
+      );
+
+      yield txt.text('aaaaaa bb cc dd ee ff g', 2, linear);
+      yield* waitFor(1);
+
+      // Resolved width 100 matches the fixed-width morph case exactly.
+      expect(lineTexts(txt)).toEqual(['aaaaaa bb ', 'c ee ff ', 'gg hh']);
+    }),
+  );
+
+  it(
+    'rewraps a percent-width Txt when its container resizes',
+    generatorTest(function* (view) {
+      const parent = (<Layout layout width={200} height={400} />) as Layout;
+      const txt = (
+        <Txt textWrap width={'100%'} text={'aaaa bbbb cccc dddd'} />
+      ) as Txt;
+      parent.add(txt);
+      view.add(parent);
+      yield;
+
+      expect(txt.textLines().lines.length).toBe(1);
+      parent.width(100);
+      yield;
+      expect(txt.textLines().lines.length).toBeGreaterThan(1);
+    }),
+  );
+
+  it(
+    'freezes tween breaks across a container resize, then reflows on settle',
+    generatorTest(function* (view) {
+      const parent = (<Layout layout width={100} height={400} />) as Layout;
+      const txt = (
+        <Txt textWrap width={'100%'} text={'aa bb cc dd ee ff gg hh'} />
+      ) as Txt;
+      parent.add(txt);
+      view.add(parent);
+      yield;
+
+      yield txt.text('aaaaaa bb cc dd ee ff g', 2, linear);
+      yield* waitFor(1);
+      const frozen = lineTexts(txt);
+      expect(frozen).toEqual(['aaaaaa bb ', 'c ee ff ', 'gg hh']);
+
+      // A concurrent container resize does not re-break the running tween...
+      parent.width(300);
+      yield;
+      expect(lineTexts(txt)).toEqual(frozen);
+
+      // ...but the settled text reflows against the new width.
+      yield* waitFor(1.5);
+      expect(lineTexts(txt)).toEqual(['aaaaaa bb cc dd ee ff g']);
+    }),
+  );
+
+  it(
+    'still suppresses wrapping for auto-width Txt mid-tween',
+    generatorTest(function* () {
+      const txt = (<Txt textWrap>aaaa bbbb cccc dddd eeee ffff</Txt>) as Txt;
+
+      yield txt.text('gggg hhhh iiii jjjj kkkk llll', 2, linear);
+      yield* waitFor(1);
+
+      expect(txt.textWrap()).toBe(false);
+    }),
+  );
+});

--- a/packages/2d/src/lib/text/knuthPlass.ts
+++ b/packages/2d/src/lib/text/knuthPlass.ts
@@ -10,7 +10,10 @@ import type {PreparedTextWithSegments} from '@chenglou/pretext';
  * the break-point graph.
  */
 
-const SOFT_HYPHEN = '­';
+/**
+ * The soft-hyphen character (U+00AD). Invisible in most editors.
+ */
+export const SOFT_HYPHEN = '­';
 const HUGE_BADNESS = 1e8;
 const RIVER_THRESHOLD = 1.5;
 const INFEASIBLE_SPACE_RATIO = 0.4;
@@ -32,6 +35,11 @@ export type KnuthPlassLine = {
   text: string;
   width: number;
   isLast: boolean;
+  /**
+   * Exclusive end segment index of this line in the prepared segments,
+   * including a terminating hard-break segment.
+   */
+  endSegmentIndex: number;
 };
 
 export type KnuthPlassOptions = {
@@ -176,26 +184,57 @@ export function knuthPlass(
   opts: KnuthPlassOptions,
 ): KnuthPlassLine[] {
   const segments = prepared.segments;
-  const widths = prepared.widths;
   const segmentCount = segments.length;
   if (segmentCount === 0) return [];
 
-  const candidates: BreakCandidate[] = [{segIndex: 0, kind: 'start'}];
-  for (let i = 0; i < segmentCount; i++) {
+  // Hard breaks split chunks, so solve each on its own.
+  const prefix = buildSegmentPrefix(segments, prepared.widths);
+  const lines: KnuthPlassLine[] = [];
+  let chunkStart = 0;
+  for (let i = 0; i <= segmentCount; i++) {
+    const atEnd = i === segmentCount;
+    if (!atEnd && segments[i] !== '\n') continue;
+    if (i > chunkStart) {
+      lines.push(
+        ...solveChunk(segments, prefix, chunkStart, i, maxWidth, opts),
+      );
+      if (!atEnd) {
+        lines[lines.length - 1].endSegmentIndex = i + 1;
+      }
+    } else if (!atEnd) {
+      lines.push({text: '', width: 0, isLast: false, endSegmentIndex: i + 1});
+    }
+    chunkStart = i + 1;
+  }
+  if (lines.length > 0) {
+    lines[lines.length - 1].isLast = true;
+  }
+  return lines;
+}
+
+function solveChunk(
+  segments: readonly string[],
+  prefix: SegmentPrefix,
+  chunkStart: number,
+  chunkEnd: number,
+  maxWidth: number,
+  opts: KnuthPlassOptions,
+): KnuthPlassLine[] {
+  const candidates: BreakCandidate[] = [{segIndex: chunkStart, kind: 'start'}];
+  for (let i = chunkStart; i < chunkEnd; i++) {
     const text = segments[i];
     if (text === SOFT_HYPHEN) {
-      if (i + 1 < segmentCount) {
+      if (i + 1 < chunkEnd) {
         candidates.push({segIndex: i + 1, kind: 'soft-hyphen'});
       }
       continue;
     }
-    if (isSpaceText(text) && i + 1 < segmentCount) {
+    if (isSpaceText(text) && i + 1 < chunkEnd) {
       candidates.push({segIndex: i + 1, kind: 'space'});
     }
   }
-  candidates.push({segIndex: segmentCount, kind: 'end'});
+  candidates.push({segIndex: chunkEnd, kind: 'end'});
 
-  const prefix = buildSegmentPrefix(segments, widths);
   const count = candidates.length;
   const dp: number[] = new Array(count).fill(Infinity);
   const previous: number[] = new Array(count).fill(-1);
@@ -247,7 +286,7 @@ export function knuthPlass(
   let from = 0;
   for (let i = 0; i < breakIndices.length; i++) {
     const to = breakIndices[i];
-    const isLast = candidates[to].kind === 'end';
+    const isChunkEnd = candidates[to].kind === 'end';
     const stats = getLineStats(
       segments,
       prefix,
@@ -259,11 +298,12 @@ export function knuthPlass(
     );
     const built = buildLineText(segments, candidates, from, to);
     const trailing =
-      built.trailingMarker === 'soft-hyphen' && !isLast ? '-' : '';
+      built.trailingMarker === 'soft-hyphen' && !isChunkEnd ? '-' : '';
     lines.push({
       text: built.text + trailing,
       width: stats.naturalWidth,
-      isLast,
+      isLast: false,
+      endSegmentIndex: candidates[to].segIndex,
     });
     from = to;
   }

--- a/packages/examples/src/scenes/text-wrap-tween.tsx
+++ b/packages/examples/src/scenes/text-wrap-tween.tsx
@@ -1,0 +1,132 @@
+import {Rect, Txt, makeScene2D} from '@canvas-commons/2d';
+import {createRef, linear, waitFor} from '@canvas-commons/core';
+
+function hyphenateWord(word: string): string[] {
+  if (word.length <= 6) return [word];
+  const parts: string[] = [];
+  for (let i = 0; i < word.length; i += 4) {
+    parts.push(word.slice(i, i + 4));
+  }
+  return parts;
+}
+
+/**
+ * Text tweens against a fixed-width, wrapping {@link Txt}: an RPG-style
+ * dialog box types and morphs its text while line breaks stay put. Each beat
+ * layers in another wrapping feature — manual newlines, hyphenation,
+ * Knuth-Plass, and exclusions — all of which keep composing mid-tween.
+ */
+export default makeScene2D(function* (view) {
+  view.fill('#0d1117');
+
+  const label = createRef<Txt>();
+  const dialog = createRef<Txt>();
+  const sigil = createRef<Rect>();
+
+  view.add(
+    <>
+      <Txt
+        ref={label}
+        anchor={[-1, 0]}
+        position={[-430, -216]}
+        fontFamily={'sans-serif'}
+        fontSize={28}
+        letterSpacing={3}
+        fill={'#6f7b8a'}
+        text={'typewriter'}
+      />
+      <Rect
+        position={[0, 60]}
+        size={[860, 460]}
+        radius={16}
+        lineWidth={4}
+        stroke={'#2e3947'}
+      >
+        <Rect
+          ref={sigil}
+          position={[280, -114]}
+          size={[200, 140]}
+          radius={12}
+          lineWidth={4}
+          stroke={'#8a6fb8'}
+          fill={'#1a1426'}
+          opacity={0}
+        />
+        <Txt
+          ref={dialog}
+          anchor={[-1, -1]}
+          position={[-380, -184]}
+          width={760}
+          textWrap
+          fontFamily={'sans-serif'}
+          fontSize={36}
+          lineHeight={52}
+          fill={'#d7dee8'}
+          text={''}
+        />
+      </Rect>
+    </>,
+  );
+
+  // Typewriter reveal along the final layout; the manual newline holds.
+  yield* dialog().text(
+    'The old druid squints at you.\n' +
+      '"Storms are coming," she says. "The pass will be buried by nightfall."',
+    3,
+    linear,
+  );
+  yield* waitFor(0.6);
+
+  // Settled lines hold their breaks while the tail still shows old text.
+  label().text('stable morph');
+  yield* dialog().text(
+    'The old druid grins at you.\n' +
+      '"Storms have passed," she says. "The pass is open until the equinox."',
+    2,
+  );
+  yield* waitFor(0.6);
+
+  // A narrow column with a hyphenator; broken words keep their visible '-'.
+  label().text('hyphenation');
+  dialog().hyphenate(() => hyphenateWord);
+  yield* dialog().width(460, 0.8);
+  yield* dialog().text(
+    'Her uncharacteristically overcomplicated topographical annotations ' +
+      'circumnavigate every impassable switchback.',
+    2,
+  );
+  yield* waitFor(0.6);
+
+  label().text('knuth-plass');
+  dialog().hyphenate(null);
+  dialog().wrapMode('knuth-plass');
+  yield* dialog().width(760, 0.8);
+  yield* dialog().text(
+    'Knuth and Plass weigh every break at once, trading a tight line here ' +
+      'for an even paragraph everywhere else.',
+    2,
+  );
+  yield* waitFor(0.6);
+
+  // Exclusion bands carve around the sigil while the text is still typing.
+  label().text('exclusions');
+  dialog().wrapMode('greedy');
+  yield* sigil().opacity(1, 0.5);
+  dialog().exclusions([
+    {
+      kind: 'rect',
+      x: 560,
+      y: 0,
+      width: 200,
+      height: 140,
+      horizontalPadding: 24,
+      verticalPadding: 12,
+    },
+  ]);
+  yield* dialog().text(
+    'The route pours itself around the warding sigil, band by band, and ' +
+      'keeps flowing while every word is still being typed.',
+    2.5,
+  );
+  yield* waitFor(1);
+});

--- a/packages/examples/src/text-wrap-tween.ts
+++ b/packages/examples/src/text-wrap-tween.ts
@@ -1,0 +1,7 @@
+import {makeProject} from '@canvas-commons/core';
+
+import scene from './scenes/text-wrap-tween?scene';
+
+export default makeProject({
+  scenes: [scene],
+});

--- a/packages/examples/vite.config.ts
+++ b/packages/examples/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         './src/text.ts',
         './src/text-split.ts',
         './src/text-path.ts',
+        './src/text-wrap-tween.ts',
       ],
     }),
   ],


### PR DESCRIPTION
## Pre-submission checks

- [ ] **Mandatory**: This PR corresponds to an issue (if not, please create one first).
- [ ] **Mandatory**: The issue has been accepted (indicated by a [`c-accepted`][label-accepted] label) and is assigned to me.
- [x] **Mandatory**: I have read and understood the [AI policy][ai-policy].
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. I have added an `Assisted-by: <tool name / model>` trailer to the commit message.

## Summary

Makes tweening behave better on wrapped Txt nodes.

## Test Plan

See test scene.

[ai-policy]: https://github.com/canvas-commons/.github/blob/main/AI_POLICY.md
[label-accepted]: https://github.com/canvas-commons/canvas-commons/issues?q=state%3Aopen%20label%3Ac-accepted
