### PR TITLE
feat(editor): timeline track sidebar with audio and media audio lanes

### DIFF
--- a/packages/2d/src/editor/Provider.tsx
+++ b/packages/2d/src/editor/Provider.tsx
@@ -1,5 +1,5 @@
 import {Node, Scene2D} from '@canvas-commons/2d';
-import {SceneRenderEvent} from '@canvas-commons/core';
+import {NODE_INSPECTOR_KEY, SceneRenderEvent} from '@canvas-commons/core';
 import {useApplication, useCurrentScene} from '@canvas-commons/editor';
 import {
   ReadonlySignal,
@@ -25,7 +25,8 @@ export interface PluginState {
 
 const PluginContext = createContext<PluginState | null>(null);
 
-export const NodeInspectorKey = '@canvas-commons/2d/node-inspector';
+/** @deprecated Use `NODE_INSPECTOR_KEY` from `@canvas-commons/core` instead. */
+export const NodeInspectorKey = NODE_INSPECTOR_KEY;
 
 export function usePluginState() {
   return useContext(PluginContext)!;
@@ -43,7 +44,7 @@ export function Provider({children}: {children?: ComponentChildren}) {
     const selectedNode = computed(() => {
       afterRender.value;
       const {key, payload} = inspection.value;
-      if (key === NodeInspectorKey) {
+      if (key === NODE_INSPECTOR_KEY) {
         return scene.value?.getNode(payload as string) ?? null;
       }
       return null;
@@ -53,10 +54,10 @@ export function Provider({children}: {children?: ComponentChildren}) {
     const selectNode = (nodeKey: string | null) => {
       const {key, payload} = inspection.peek();
 
-      if (key === NodeInspectorKey && !nodeKey) {
+      if (key === NODE_INSPECTOR_KEY && !nodeKey) {
         inspection.value = {key: '', payload: null};
       } else if (payload !== nodeKey) {
-        inspection.value = {key: NodeInspectorKey, payload: nodeKey};
+        inspection.value = {key: NODE_INSPECTOR_KEY, payload: nodeKey};
       }
     };
 

--- a/packages/2d/src/lib/components/Video.ts
+++ b/packages/2d/src/lib/components/Video.ts
@@ -6,15 +6,18 @@ import {
   SignalValue,
   SimpleSignal,
   clamp,
+  gainToDb,
   isReactive,
   useLogger,
   useThread,
+  viaProxy,
 } from '@canvas-commons/core';
 import {computed, initial, nodeName, signal} from '../decorators';
 import {DesiredLength} from '../partials';
 import {drawImage} from '../utils';
-import {Rect, RectProps} from './Rect';
 import reactivePlaybackRate from './__logs__/reactive-playback-rate';
+import {MediaAudioClip} from './mediaAudioClip';
+import {Rect, RectProps} from './Rect';
 
 export interface VideoProps extends RectProps {
   /**
@@ -42,11 +45,19 @@ export interface VideoProps extends RectProps {
    */
   time?: SignalValue<number>;
   play?: boolean;
+  /**
+   * {@inheritDoc Video.volume}
+   */
+  volume?: SignalValue<number>;
 }
 
 @nodeName('Video')
 export class Video extends Rect {
   private static readonly pool: Record<string, HTMLVideoElement> = {};
+  // Resolved durations keyed by source. Once a source's metadata has loaded,
+  // its duration is remembered so later recalculations (which recreate the
+  // element or race against not-yet-ready metadata) never collapse back to 0.
+  private static readonly durationCache: Map<string, number> = new Map();
 
   /**
    * The source of this video.
@@ -106,6 +117,19 @@ export class Video extends Rect {
   @signal()
   declare public readonly playbackRate: SimpleSignal<number, this>;
 
+  /**
+   * The volume of this video's own embedded audio.
+   *
+   * @remarks
+   * `1` plays the source audio unmodified. Applies during both live preview
+   * and export.
+   *
+   * @defaultValue 1
+   */
+  @initial(1)
+  @signal()
+  declare public readonly volume: SimpleSignal<number, this>;
+
   @initial(0)
   @signal()
   declare protected readonly time: SimpleSignal<number, this>;
@@ -115,6 +139,7 @@ export class Video extends Rect {
   declare protected readonly playing: SimpleSignal<boolean, this>;
 
   private lastTime = -1;
+  private readonly audio = new MediaAudioClip();
 
   public constructor({play, ...props}: VideoProps) {
     super(props);
@@ -139,7 +164,49 @@ export class Video extends Rect {
   }
 
   public getDuration(): number {
-    return this.video().duration;
+    const src = this.src();
+    // Reading the duration only needs metadata, not full playback readiness.
+    // Access the pooled element directly instead of through `video()`, which
+    // would register a `canplay` dependency and make the recalculation wait for
+    // the whole clip to buffer before the duration could ever settle.
+    const video = this.metadataElement();
+    // `duration` is only known once the element has loaded its metadata
+    // (readyState >= HAVE_METADATA). Reading it earlier yields NaN, which -
+    // passed on to e.g. `waitFor` - would corrupt the scene's computed
+    // duration. Register a metadata-ready promise so the recalculation retries
+    // once the value is known, and report 0 in the meantime rather than NaN.
+    if (video.readyState < 1 || !isFinite(video.duration)) {
+      // A previously resolved duration for the same source survives element
+      // recreation and readiness races: reuse it so a scene with several
+      // sequential videos doesn't collapse the ones whose element happens not
+      // to be ready on a given recalculation pass.
+      const cached = Video.durationCache.get(src);
+      if (cached !== undefined) {
+        return cached;
+      }
+      DependencyContext.collectPromise(
+        new Promise<void>(resolve => {
+          const listener = () => {
+            // Record the resolved duration as soon as metadata arrives. Large
+            // offscreen videos may have their readiness reset by the browser
+            // between recalculation passes; caching here ensures the value
+            // survives so the scene duration doesn't collapse to the clips that
+            // happen to still be ready on the final pass.
+            if (isFinite(video.duration)) {
+              Video.durationCache.set(src, video.duration);
+            }
+            resolve();
+            video.removeEventListener('loadedmetadata', listener);
+            video.removeEventListener('durationchange', listener);
+          };
+          video.addEventListener('loadedmetadata', listener);
+          video.addEventListener('durationchange', listener);
+        }),
+      );
+      return 0;
+    }
+    Video.durationCache.set(src, video.duration);
+    return video.duration;
   }
 
   protected override desiredSize(): SerializedVector2<DesiredLength> {
@@ -167,16 +234,43 @@ export class Video extends Rect {
     return this.clampTime(this.time()) / this.video().duration;
   }
 
-  @computed()
-  protected video(): HTMLVideoElement {
-    const src = this.src();
-    const key = `${this.key}/${src}`;
-    let video = Video.pool[key];
+  // Resolve the raw src into a same-origin, cache-busted url and a pool key.
+  // Remote sources are routed through the cors proxy so the canvas is not
+  // CORS-tainted, which would make `getImageData` throw ("operation is
+  // insecure") when the renderer reads frames for export.
+  private resolveSource(): {src: string; poolKey: string} {
+    const rawSrc = this.src();
+    if (!rawSrc) {
+      return {src: '', poolKey: `${this.key}/`};
+    }
+    const proxied = viaProxy(rawSrc);
+    const url = new URL(proxied, window.location.origin);
+    if (url.origin === window.location.origin) {
+      url.searchParams.set('asset-hash', this.view().assetHash());
+    }
+    return {src: url.toString(), poolKey: `${this.key}/${proxied}`};
+  }
+
+  private metadataElement(): HTMLVideoElement {
+    const {src, poolKey} = this.resolveSource();
+    let video = Video.pool[poolKey];
     if (!video) {
       video = document.createElement('video');
+      // Ensure the browser fetches metadata eagerly instead of deferring it,
+      // so a duration read during recalculation settles promptly.
+      video.preload = 'auto';
+      video.volume = 0;
+      video.muted = true;
+      video.crossOrigin = 'anonymous';
       video.src = src;
-      Video.pool[key] = video;
+      Video.pool[poolKey] = video;
     }
+    return video;
+  }
+
+  @computed()
+  protected video(): HTMLVideoElement {
+    const video = this.metadataElement();
 
     if (video.readyState < 2) {
       DependencyContext.collectPromise(
@@ -236,6 +330,11 @@ export class Video extends Rect {
       }
     }
 
+    // While playing, let the native element free-run so it keeps delivering
+    // fully decoded frames. Seeking it every frame would leave it perpetually
+    // in a `seeking` state, so `drawImage` would sample blank frames and the
+    // video would blink. Only correct when it drifts far from the animation
+    // clock.
     if (Math.abs(video.currentTime - time) > 0.2) {
       this.setCurrentTime(time);
     } else if (!playing) {
@@ -334,16 +433,19 @@ export class Video extends Rect {
     const playbackRate = this.playbackRate();
     this.playing(true);
     this.time(() => this.clampTime(offset + (time() - start) * playbackRate));
+    this.registerAudioClip(offset);
   }
 
   public pause() {
     this.playing(false);
     this.time.save();
     this.video().pause();
+    this.finalizeAudioClip();
   }
 
   public seek(time: number) {
     const playing = this.playing();
+    this.finalizeAudioClip();
     this.time(this.clampTime(time));
     if (playing) {
       this.play();
@@ -354,14 +456,85 @@ export class Video extends Rect {
 
   public clampTime(time: number): number {
     const duration = this.video().duration;
+    // The duration is NaN until the element reports metadata (and after the
+    // pooled element is torn down). Looping would then take the modulo against
+    // NaN, poisoning `time` - and anything derived from it, such as a media
+    // clip's `end` - with NaN. Skip clamping until a real duration is known.
+    if (!isFinite(duration)) {
+      return Math.max(0, time);
+    }
     if (this.loop()) {
       time %= duration;
     }
     return clamp(0, duration, time);
   }
 
+  /**
+   * Resolve the current playback time from teardown paths without reporting
+   * unresolved async properties.
+   *
+   * @remarks
+   * After {@link play}, the `time` signal holds a reactive function that calls
+   * {@link clampTime} - and therefore {@link video} - when read. During
+   * disposal the node is no longer ready, so evaluating it would register a
+   * pending promise and log "accessed an asynchronous property before the node
+   * was ready". Suppressing promise collection lets us read the last resolved
+   * time and clamp it against the pooled element's duration instead.
+   */
+  private currentTimeSafely(): number {
+    const rawTime = DependencyContext.collectingPromisesSuppressed(() =>
+      this.time(),
+    );
+    // A looping video's `time` signal resolves through `clampTime`, which takes
+    // the modulo against the element's duration. When that duration is not yet
+    // known (e.g. the pooled element was torn down or never became ready) the
+    // modulo yields NaN, which would otherwise be stored as the clip's `end`
+    // and break its waveform. Fall back to the last resolved time in that case.
+    const time = isFinite(rawTime) ? rawTime : Math.max(0, this.lastTime);
+    const duration = Video.pool[this.resolveSource().poolKey]?.duration;
+    if (!duration || !isFinite(duration)) {
+      return Math.max(0, time);
+    }
+    return clamp(0, duration, this.loop() ? time % duration : time);
+  }
+
+  // A muted clip (volume 0) produces no audio, so skip registering it
+  // entirely. This also avoids a -Infinity dB gain, which JSON-serializes to
+  // null on its way to the export server.
+  private isAudible(): boolean {
+    return this.volume() > 0;
+  }
+
+  private registerAudioClip(startTime: number) {
+    this.finalizeAudioClip();
+    if (!this.isAudible()) {
+      return;
+    }
+    this.audio.register({
+      audio: this.src(),
+      start: startTime,
+      gain: gainToDb(this.volume()),
+      playbackRate: this.playbackRate(),
+      sourceKey: this.key,
+      origin: 'media',
+    });
+  }
+
+  /**
+   * Close off the in-progress audio clip (if any) at the video's current
+   * time, or discard it if it ended up covering no duration.
+   */
+  private finalizeAudioClip() {
+    this.audio.finalize(() => this.currentTimeSafely());
+  }
+
   protected override collectAsyncResources() {
     super.collectAsyncResources();
     this.seekedVideo();
+  }
+
+  public override dispose() {
+    this.finalizeAudioClip();
+    super.dispose();
   }
 }

--- a/packages/2d/src/lib/components/__tests__/videoAudio.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/videoAudio.test.tsx
@@ -1,0 +1,435 @@
+import {DependencyContext, useScene, waitFor} from '@canvas-commons/core';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {Video} from '../Video';
+import {generatorTest} from './generatorTest';
+import {mockScene2D} from './mockScene2D';
+
+class TestVideo extends Video {
+  public element(): HTMLVideoElement {
+    return this.video();
+  }
+
+  public duration(): number {
+    return this.getDuration();
+  }
+
+  public syncPlayback(): HTMLVideoElement {
+    // The editor consumes the element's play() promise during its render loop;
+    // suppress collection here so directly invoking the sync in tests does not
+    // leak that resolved-but-unconsumed promise across cases.
+    return DependencyContext.collectingPromisesSuppressed(() =>
+      this.fastSeekedVideo(),
+    );
+  }
+}
+
+function makeReady(video: TestVideo, duration: number): HTMLVideoElement {
+  const element = video.element();
+  Object.defineProperty(element, 'duration', {
+    value: duration,
+    configurable: true,
+  });
+  return element;
+}
+
+describe('Video audio', () => {
+  mockScene2D();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // jsdom's HTMLMediaElement never becomes ready on its own; report ready
+    // immediately so `Video.video()` never registers an async `canplay`
+    // wait (which nothing in these tests would ever consume/drain).
+    vi.spyOn(HTMLMediaElement.prototype, 'readyState', 'get').mockReturnValue(
+      4,
+    );
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+  });
+
+  it('always silences the underlying <video> element', () => {
+    const video = (<TestVideo src="clip.mp4" volume={1} />) as TestVideo;
+    const element = video.element();
+    expect(element.muted).toBe(true);
+    expect(element.volume).toBe(0);
+  });
+
+  it(
+    'registers a sound clip while playing',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+      makeReady(video, 10);
+
+      video.play();
+      expect(useScene().sounds.getSounds()).toHaveLength(1);
+      const [clip] = useScene().sounds.getSounds();
+      expect(clip.audio).toBe('clip.mp4');
+      expect(clip.start).toBe(0);
+      expect(clip.end).toBeUndefined();
+      expect(clip.sourceKey).toBe(video.key);
+
+      yield* waitFor(2);
+      video.pause();
+
+      const [finalized] = useScene().sounds.getSounds();
+      expect(finalized.end).toBeCloseTo(2, 1);
+    }),
+  );
+
+  it(
+    'applies volume as gain in dB',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" volume={0.5} />) as TestVideo;
+      makeReady(video, 10);
+
+      video.play();
+      const [clip] = useScene().sounds.getSounds();
+      expect(clip.gain).toBeCloseTo(-6.02, 1);
+      video.pause();
+    }),
+  );
+
+  it(
+    'registers no audio clip when muted (volume 0)',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" volume={0} />) as TestVideo;
+      makeReady(video, 10);
+
+      video.play();
+      yield* waitFor(1);
+      expect(useScene().sounds.getSounds()).toHaveLength(0);
+      video.pause();
+    }),
+  );
+
+  it(
+    'discards a clip that ends up covering no duration',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+      makeReady(video, 10);
+
+      video.play();
+      expect(useScene().sounds.getSounds()).toHaveLength(1);
+      video.pause();
+      expect(useScene().sounds.getSounds()).toHaveLength(0);
+    }),
+  );
+
+  it(
+    'finalizes its in-progress clip on dispose',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+      makeReady(video, 10);
+
+      video.play();
+      yield* waitFor(1);
+      expect(useScene().sounds.getSounds()).toHaveLength(1);
+
+      video.dispose();
+      const [clip] = useScene().sounds.getSounds();
+      expect(clip.end).toBeCloseTo(1, 1);
+    }),
+  );
+
+  it(
+    'discards its clip on dispose if it never accrued duration',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+      makeReady(video, 10);
+
+      video.play();
+      expect(useScene().sounds.getSounds()).toHaveLength(1);
+
+      video.dispose();
+      expect(useScene().sounds.getSounds()).toHaveLength(0);
+    }),
+  );
+
+  it(
+    'finalizes a looping clip with a finite end when the duration is unknown',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" loop />) as TestVideo;
+      // Deliberately leave the element duration as NaN (never `makeReady`),
+      // mirroring a pooled element that has been torn down. Looping used to
+      // take the modulo against NaN, storing NaN as the clip's `end`.
+      video.play();
+      yield* waitFor(1);
+      expect(useScene().sounds.getSounds()).toHaveLength(1);
+
+      video.dispose();
+      const [clip] = useScene().sounds.getSounds();
+      expect(clip.end).toBeDefined();
+      expect(Number.isFinite(clip.end)).toBe(true);
+      expect(clip.end).toBeCloseTo(1, 1);
+    }),
+  );
+
+  it(
+    'keeps the current time finite for a looping video without a duration',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" loop />) as TestVideo;
+      video.play();
+      yield* waitFor(2);
+      expect(Number.isFinite(video.getCurrentTime())).toBe(true);
+      video.pause();
+    }),
+  );
+
+  it(
+    'finalizes the previous clip and starts a new one on seek while playing',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+      makeReady(video, 10);
+
+      video.play();
+      yield* waitFor(1);
+      video.seek(5);
+
+      const sounds = useScene().sounds.getSounds();
+      expect(sounds).toHaveLength(2);
+      expect(sounds[0].start).toBe(0);
+      expect(sounds[0].end).toBeCloseTo(1, 1);
+      expect(sounds[1].start).toBeCloseTo(5, 1);
+      video.pause();
+    }),
+  );
+});
+
+describe('Video playback sync', () => {
+  mockScene2D();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(HTMLMediaElement.prototype, 'readyState', 'get').mockReturnValue(
+      4,
+    );
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    // jsdom never dispatches `seeked`, so a seek that reports `seeking` would
+    // register a promise that nothing resolves and leaks across tests.
+    vi.spyOn(HTMLMediaElement.prototype, 'seeking', 'get').mockReturnValue(
+      false,
+    );
+  });
+
+  function trackCurrentTime(element: HTMLVideoElement): number[] {
+    const history: number[] = [];
+    let value = 0;
+    Object.defineProperty(element, 'currentTime', {
+      configurable: true,
+      get: () => value,
+      set: (next: number) => {
+        value = next;
+        history.push(next);
+      },
+    });
+    return history;
+  }
+
+  it(
+    'does not seek the element every frame while playing',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+      const element = makeReady(video, 10);
+      const history = trackCurrentTime(element);
+
+      // A real element advances its own currentTime while playing; emulate that
+      // so it stays in sync and never trips the large-drift correction.
+      video.play();
+      for (let i = 0; i < 30; i++) {
+        (element as unknown as {currentTime: number}).currentTime =
+          video.getCurrentTime();
+        history.length = 0;
+        yield* waitFor(1 / 30);
+        video.syncPlayback();
+      }
+      video.pause();
+
+      // Seeking a playing element every frame leaves it perpetually mid-seek,
+      // so `drawImage` samples blank frames and the video blinks. While it
+      // tracks the animation clock we must not issue any per-frame seek.
+      expect(history.length).toBe(0);
+    }),
+  );
+
+  it(
+    'corrects the element only when it drifts far from the animation clock',
+    generatorTest(function* () {
+      const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+      const element = makeReady(video, 10);
+
+      video.play();
+      yield* waitFor(1 / 30);
+
+      // Element sitting within tolerance: no correction.
+      (element as unknown as {currentTime: number}).currentTime =
+        video.getCurrentTime();
+      const history = trackCurrentTime(element);
+      video.syncPlayback();
+      expect(history.length).toBe(0);
+
+      // Element drifted far ahead (editor lagged): a single correction fires.
+      (element as unknown as {currentTime: number}).currentTime =
+        video.getCurrentTime() + 1;
+      history.length = 0;
+      yield* waitFor(1 / 30);
+      video.syncPlayback();
+      expect(history.length).toBeGreaterThan(0);
+
+      video.pause();
+    }),
+  );
+});
+
+describe('Video CORS', () => {
+  mockScene2D();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    import.meta.env.VITE_MC_PROXY_ENABLED = undefined;
+    import.meta.env.VITE_MC_PROXY_ALLOW_LIST = undefined;
+  });
+
+  const elementOf = (video: TestVideo): HTMLVideoElement =>
+    DependencyContext.collectingPromisesSuppressed(() => video.element());
+
+  it('requests the element anonymously so the export canvas is not tainted', () => {
+    vi.spyOn(HTMLMediaElement.prototype, 'readyState', 'get').mockReturnValue(
+      4,
+    );
+    const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+    expect(elementOf(video).crossOrigin).toBe('anonymous');
+  });
+
+  it('routes a remote src through the cors proxy when enabled', () => {
+    vi.spyOn(HTMLMediaElement.prototype, 'readyState', 'get').mockReturnValue(
+      4,
+    );
+    import.meta.env.VITE_MC_PROXY_ENABLED = 'true';
+    import.meta.env.VITE_MC_PROXY_ALLOW_LIST = JSON.stringify([]);
+    const remote = 'https://i.imgflip.com/5utid6.mp4';
+    const video = (<TestVideo src={remote} />) as TestVideo;
+    expect(elementOf(video).getAttribute('src')).toContain(
+      '/cors-proxy/' + encodeURIComponent(remote),
+    );
+  });
+
+  it('leaves a local src same-origin (no proxy)', () => {
+    vi.spyOn(HTMLMediaElement.prototype, 'readyState', 'get').mockReturnValue(
+      4,
+    );
+    import.meta.env.VITE_MC_PROXY_ENABLED = 'true';
+    import.meta.env.VITE_MC_PROXY_ALLOW_LIST = JSON.stringify([]);
+    const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+    expect(elementOf(video).getAttribute('src')).not.toContain('/cors-proxy/');
+  });
+});
+
+describe('Video.getDuration', () => {
+  mockScene2D();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+  });
+
+  it('returns 0 instead of NaN before metadata loads', () => {
+    vi.spyOn(HTMLMediaElement.prototype, 'readyState', 'get').mockReturnValue(
+      0,
+    );
+    const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+
+    // Duration is NaN until the element reports metadata; getDuration must not
+    // leak that NaN (which would corrupt `waitFor`/timeline). Suppress promise
+    // collection so the jsdom element's never-resolving readiness listeners do
+    // not leak into other tests.
+    let duration = NaN;
+    DependencyContext.collectingPromisesSuppressed(() => {
+      duration = video.duration();
+    });
+    expect(duration).toBe(0);
+  });
+
+  it('returns the real duration once metadata is available', () => {
+    vi.spyOn(HTMLMediaElement.prototype, 'readyState', 'get').mockReturnValue(
+      4,
+    );
+    const video = (<TestVideo src="clip.mp4" />) as TestVideo;
+    const element = video.element();
+    Object.defineProperty(element, 'duration', {
+      value: 12.5,
+      configurable: true,
+    });
+
+    let duration = NaN;
+    DependencyContext.collectingPromisesSuppressed(() => {
+      duration = video.duration();
+    });
+    expect(duration).toBe(12.5);
+  });
+
+  it('reuses a previously resolved duration when the element is not ready', () => {
+    const ready = vi
+      .spyOn(HTMLMediaElement.prototype, 'readyState', 'get')
+      .mockReturnValue(4);
+    const video = (<TestVideo src="cached-clip.mp4" />) as TestVideo;
+    const element = video.element();
+    Object.defineProperty(element, 'duration', {
+      value: 42,
+      configurable: true,
+    });
+
+    let first = NaN;
+    DependencyContext.collectingPromisesSuppressed(() => {
+      first = video.duration();
+    });
+    expect(first).toBe(42);
+
+    // The element becomes not-ready again (mirroring a torn-down/reloading
+    // pooled element during a later recalculation). A fresh node for the same
+    // source must still report the cached duration instead of collapsing to 0.
+    ready.mockReturnValue(0);
+    const other = (<TestVideo src="cached-clip.mp4" />) as TestVideo;
+    let second = NaN;
+    DependencyContext.collectingPromisesSuppressed(() => {
+      second = other.duration();
+    });
+    expect(second).toBe(42);
+  });
+
+  it('caches the duration once metadata loads for a not-ready element', () => {
+    vi.spyOn(HTMLMediaElement.prototype, 'readyState', 'get').mockReturnValue(
+      0,
+    );
+    const video = (<TestVideo src="late-clip.mp4" />) as TestVideo;
+    const element = video.element();
+    Object.defineProperty(element, 'duration', {
+      value: 99,
+      configurable: true,
+    });
+
+    let first = NaN;
+    DependencyContext.collectingPromisesSuppressed(() => {
+      first = video.duration();
+    });
+    // Not ready yet: reports 0 and registers a metadata listener.
+    expect(first).toBe(0);
+
+    // Metadata arrives; the listener records the duration in the cache even
+    // though the element is still reported as not-ready.
+    element.dispatchEvent(new Event('loadedmetadata'));
+
+    const other = (<TestVideo src="late-clip.mp4" />) as TestVideo;
+    let second = NaN;
+    DependencyContext.collectingPromisesSuppressed(() => {
+      second = other.duration();
+    });
+    expect(second).toBe(99);
+  });
+});

--- a/packages/2d/src/lib/components/mediaAudioClip.ts
+++ b/packages/2d/src/lib/components/mediaAudioClip.ts
@@ -1,0 +1,109 @@
+import {
+  Scene,
+  Sound,
+  SoundOrigin,
+  useLogger,
+  useMediaAudioAnalyzer,
+  useScene,
+} from '@canvas-commons/core';
+
+export interface MediaAudioClipConfig {
+  audio: string;
+  start: number;
+  gain: number;
+  playbackRate: number;
+  sourceKey: string;
+  origin: SoundOrigin;
+}
+
+export interface MediaAudioClipHandle {
+  clip: Sound;
+  scene: Scene;
+  token: number;
+}
+
+export class MediaAudioClip {
+  private handle: MediaAudioClipHandle | null = null;
+  private registrationToken = 0;
+
+  public register(config: MediaAudioClipConfig): void {
+    const scene = useScene();
+    const clip = scene.sounds.add(
+      {
+        audio: config.audio,
+        start: config.start,
+        gain: config.gain,
+        playbackRate: config.playbackRate,
+        sourceKey: config.sourceKey,
+        origin: config.origin,
+      },
+      0,
+    );
+    const token = ++this.registrationToken;
+    this.handle = {clip, scene, token};
+
+    const analyzer = useMediaAudioAnalyzer();
+    analyzer
+      .hasAudio(config.audio)
+      .then(hasAudio => {
+        if (!hasAudio) {
+          scene.sounds.remove(clip);
+          if (this.handle?.clip === clip) {
+            this.handle = null;
+          }
+        }
+      })
+      .catch(e => {
+        useLogger().warn({
+          message: `Could not analyze audio for "${config.audio}".`,
+          remarks: String(e),
+          inspect: config.sourceKey,
+        });
+      });
+  }
+
+  // Timeline placement of the registered clip, or null before it registers.
+  public placement(): {
+    offset: number;
+    start: number;
+    playbackRate: number;
+  } | null {
+    const clip = this.handle?.clip;
+    if (!clip) {
+      return null;
+    }
+    return {
+      offset: clip.offset,
+      start: clip.start ?? 0,
+      playbackRate: clip.realPlaybackRate,
+    };
+  }
+
+  /**
+   * Close off the in-progress clip.
+   *
+   * @param resolveEndTime - Resolves the timeline position to stop the clip at.
+   * A clip covering no duration is discarded.
+   */
+  public finalize(resolveEndTime: () => number): void {
+    const handle = this.handle;
+    if (!handle) {
+      return;
+    }
+    this.handle = null;
+    const endTime = resolveEndTime();
+    if (endTime <= (handle.clip.start ?? 0)) {
+      handle.scene.sounds.remove(handle.clip);
+      return;
+    }
+    handle.clip.end = endTime;
+  }
+
+  /**
+   * Drop the reference to the in-progress clip without truncating it, leaving
+   * its `end` untouched so it plays/draws to the source's natural end.
+   */
+  public release(): void {
+    this.handle = null;
+  }
+}

--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -23,6 +23,8 @@ export interface PlayerState extends Record<string, unknown> {
   speed: number;
   projectAudioMuted: boolean;
   projectAudioSolo: boolean;
+  mediaAudioMuted: boolean;
+  mediaAudioSolo: boolean;
 }
 
 export interface PlayerSettings {
@@ -139,6 +141,8 @@ export class Player {
       speed: 1,
       projectAudioMuted: false,
       projectAudioSolo: false,
+      mediaAudioMuted: false,
+      mediaAudioSolo: false,
       ...initialState,
       paused: true,
     });
@@ -316,6 +320,20 @@ export class Player {
       projectAudioSolo: solo,
     };
   }
+  public toggleMediaAudioMuted(value?: boolean): void {
+    const muted = value ?? !this.playerState.current.mediaAudioMuted;
+    this.playerState.current = {
+      ...this.playerState.current,
+      mediaAudioMuted: muted,
+    };
+  }
+  public toggleMediaAudioSolo(value?: boolean): void {
+    const solo = value ?? !this.playerState.current.mediaAudioSolo;
+    this.playerState.current = {
+      ...this.playerState.current,
+      mediaAudioSolo: solo,
+    };
+  }
   public setAudioVolume(value: number): void {
     const clampedValue = clamp(0, 1, value);
     if (clampedValue !== this.playerState.current.volume) {
@@ -440,10 +458,22 @@ export class Player {
       state.seek = this.startFrame;
     }
 
+    // A soloed track silences the others; without any solo, only per-track
+    // mute applies (on top of the global mute).
+    const anySolo = state.mediaAudioSolo || state.projectAudioSolo;
+    const mediaMuted =
+      state.muted ||
+      state.mediaAudioMuted ||
+      (anySolo && !state.mediaAudioSolo);
+    const projectMuted =
+      state.muted ||
+      state.projectAudioMuted ||
+      (anySolo && !state.projectAudioSolo);
+
     // Pause / play sounds.
     this.audioPool.prepare(this.status.time);
     await this.audioPool.setPaused(state.paused || this.finished);
-    this.audioPool.setMuted(state.muted || state.projectAudioSolo);
+    this.audioPool.setMuted(mediaMuted);
     this.audioPool.setVolume(state.volume);
 
     // Pause / play audio.
@@ -452,7 +482,7 @@ export class Player {
     if (await this.audio.setPaused(audioPaused)) {
       this.syncAudio(-3);
     }
-    this.audio.setMuted(state.muted || state.projectAudioMuted);
+    this.audio.setMuted(projectMuted);
     this.audio.setVolume(state.volume);
 
     return state;

--- a/packages/core/src/app/Player.ts
+++ b/packages/core/src/app/Player.ts
@@ -21,6 +21,8 @@ export interface PlayerState extends Record<string, unknown> {
   muted: boolean;
   volume: number;
   speed: number;
+  projectAudioMuted: boolean;
+  projectAudioSolo: boolean;
 }
 
 export interface PlayerSettings {
@@ -135,6 +137,8 @@ export class Player {
       muted: true,
       volume: 1,
       speed: 1,
+      projectAudioMuted: false,
+      projectAudioSolo: false,
       ...initialState,
       paused: true,
     });
@@ -298,6 +302,20 @@ export class Player {
     }
   }
 
+  public toggleProjectAudioMuted(value?: boolean): void {
+    const muted = value ?? !this.playerState.current.projectAudioMuted;
+    this.playerState.current = {
+      ...this.playerState.current,
+      projectAudioMuted: muted,
+    };
+  }
+  public toggleProjectAudioSolo(value?: boolean): void {
+    const solo = value ?? !this.playerState.current.projectAudioSolo;
+    this.playerState.current = {
+      ...this.playerState.current,
+      projectAudioSolo: solo,
+    };
+  }
   public setAudioVolume(value: number): void {
     const clampedValue = clamp(0, 1, value);
     if (clampedValue !== this.playerState.current.volume) {
@@ -425,7 +443,7 @@ export class Player {
     // Pause / play sounds.
     this.audioPool.prepare(this.status.time);
     await this.audioPool.setPaused(state.paused || this.finished);
-    this.audioPool.setMuted(state.muted);
+    this.audioPool.setMuted(state.muted || state.projectAudioSolo);
     this.audioPool.setVolume(state.volume);
 
     // Pause / play audio.
@@ -434,7 +452,7 @@ export class Player {
     if (await this.audio.setPaused(audioPaused)) {
       this.syncAudio(-3);
     }
-    this.audio.setMuted(state.muted);
+    this.audio.setMuted(state.muted || state.projectAudioMuted);
     this.audio.setVolume(state.volume);
 
     return state;

--- a/packages/core/src/flow/scheduling.test.ts
+++ b/packages/core/src/flow/scheduling.test.ts
@@ -78,4 +78,27 @@ describe('waitFor()', () => {
     expect(playback.frame).toBe(4);
     expect(time).toBeCloseTo(0.45);
   });
+
+  test('Non-finite duration does not hang or corrupt the timeline', () => {
+    let nanTime = NaN;
+    let infTime = NaN;
+    const task = threads(function* () {
+      yield* waitFor(NaN);
+      nanTime = useTime();
+      yield* waitFor(Infinity);
+      infTime = useTime();
+    });
+
+    playback.fps = 10;
+    playback.frame = 0;
+    let iterations = 0;
+    for (const _ of task) {
+      playback.frame++;
+      if (++iterations > 100) break;
+    }
+
+    expect(iterations).toBeLessThan(100);
+    expect(nanTime).toBe(0);
+    expect(infTime).toBe(0);
+  });
 });

--- a/packages/core/src/flow/scheduling.ts
+++ b/packages/core/src/flow/scheduling.ts
@@ -1,6 +1,6 @@
 import {decorate, threadable} from '../decorators';
 import {ThreadGenerator} from '../threading';
-import {useDuration, usePlayback, useThread} from '../utils';
+import {useDuration, useLogger, usePlayback, useThread} from '../utils';
 
 decorate(waitUntil, threadable());
 /**
@@ -51,6 +51,18 @@ export function* waitFor(
 ): ThreadGenerator {
   const thread = useThread();
   const step = usePlayback().framesToSeconds(1);
+
+  // A non-finite duration (e.g. `video.getDuration()` read before the element's
+  // metadata loaded returns NaN) would otherwise poison the thread time and,
+  // through it, the scene's computed duration - leaving the editor unable to
+  // settle on a timeline and spinning in an endless recalculation. Treat it as
+  // no wait instead of corrupting the timeline.
+  if (!isFinite(seconds)) {
+    useLogger().warn(
+      `waitFor received a non-finite duration (${seconds}); waiting for 0 seconds instead.`,
+    );
+    seconds = 0;
+  }
 
   const targetTime = thread.time() + seconds;
   // subtracting the step is not necessary, but it keeps the thread time ahead

--- a/packages/core/src/media/AudioResourceManager.ts
+++ b/packages/core/src/media/AudioResourceManager.ts
@@ -1,5 +1,6 @@
 import {Logger} from '../app';
 import {ValueDispatcher} from '../events';
+import {viaProxy} from '../utils';
 import {AudioData, EMPTY_AUDIO_DATA} from './AudioData';
 
 export class AudioResourceManager {
@@ -60,7 +61,7 @@ export class AudioResource {
   private async loadData(signal: AbortSignal): Promise<AudioData | void> {
     let response: Response;
     try {
-      response = await fetch(this.source, {signal});
+      response = await fetch(viaProxy(this.source), {signal});
     } catch (e: any) {
       if (e.name !== 'AbortError') {
         this.logger.error(e);

--- a/packages/core/src/media/MediaAudioAnalyzer.test.ts
+++ b/packages/core/src/media/MediaAudioAnalyzer.test.ts
@@ -1,0 +1,102 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {MediaAudioAnalyzer} from './MediaAudioAnalyzer';
+
+function stubFetchOk(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => new ArrayBuffer(8),
+    })),
+  );
+}
+
+function stubAudioContext(
+  decode: () => Promise<AudioBuffer> | AudioBuffer,
+): void {
+  vi.stubGlobal(
+    'AudioContext',
+    class {
+      public decodeAudioData = vi.fn(async () => decode());
+    },
+  );
+}
+
+function fakeAudioBuffer(peak = 0.5): AudioBuffer {
+  const data = new Float32Array(48000);
+  if (peak !== 0) {
+    data[0] = peak;
+    data[1] = -peak;
+  }
+  return {
+    numberOfChannels: 1,
+    sampleRate: 48000,
+    duration: 1,
+    length: data.length,
+    getChannelData: () => data,
+  } as unknown as AudioBuffer;
+}
+
+describe('MediaAudioAnalyzer.hasAudio', () => {
+  beforeEach(() => {
+    stubFetchOk();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('reports true when the source has an audible audio track', async () => {
+    stubAudioContext(() => fakeAudioBuffer(0.5));
+    const analyzer = new MediaAudioAnalyzer();
+    expect(await analyzer.hasAudio('with-audio.mp4')).toBe(true);
+  });
+
+  it('reports false when the source has no decodable audio track', async () => {
+    stubAudioContext(() => {
+      throw new Error('no audio');
+    });
+    const analyzer = new MediaAudioAnalyzer();
+    expect(await analyzer.hasAudio('no-audio.mp4')).toBe(false);
+  });
+
+  it('reports false for a decodable but silent audio track', async () => {
+    stubAudioContext(() => fakeAudioBuffer(0));
+    const analyzer = new MediaAudioAnalyzer();
+    expect(await analyzer.hasAudio('silent-track.mp4')).toBe(false);
+  });
+
+  it('reports false for a near-silent (noise-floor) audio track', async () => {
+    stubAudioContext(() => fakeAudioBuffer(0.0002));
+    const analyzer = new MediaAudioAnalyzer();
+    expect(await analyzer.hasAudio('noise-floor.mp4')).toBe(false);
+  });
+
+  it('reports false when the source cannot be fetched', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ok: false, status: 404})),
+    );
+    stubAudioContext(() => fakeAudioBuffer());
+    const analyzer = new MediaAudioAnalyzer();
+    expect(await analyzer.hasAudio('missing.mp4')).toBe(false);
+  });
+
+  it('decodes each source only once across repeated hasAudio calls', async () => {
+    const decode = vi.fn(async () => fakeAudioBuffer());
+    vi.stubGlobal(
+      'AudioContext',
+      class {
+        public decodeAudioData = decode;
+      },
+    );
+    const analyzer = new MediaAudioAnalyzer();
+
+    await analyzer.hasAudio('clip.mp4');
+    await analyzer.hasAudio('clip.mp4');
+
+    expect(decode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/media/MediaAudioAnalyzer.ts
+++ b/packages/core/src/media/MediaAudioAnalyzer.ts
@@ -1,0 +1,128 @@
+import {useLogger, viaProxy} from '../utils';
+
+interface DecodedAudio {
+  channels: Float32Array[];
+  sampleRate: number;
+  peakAmplitude: number;
+}
+
+interface CacheEntry {
+  decoded: Promise<DecodedAudio | null>;
+}
+
+/**
+ * Peak amplitude below which an audio track is treated as effectively silent
+ * (no audible signal). Chosen well above typical dither/noise floors (~-90 dB)
+ * but below any real content, so muxed-in silent audio tracks are ignored.
+ */
+const SILENCE_PEAK_THRESHOLD = 0.001;
+
+/**
+ * Decodes media audio sources and reports whether they carry audible audio,
+ * caching results by source URL so repeated timeline recalculations of the
+ * same `Video` clip don't re-fetch/re-decode the file.
+ */
+export class MediaAudioAnalyzer {
+  private readonly cache = new Map<string, CacheEntry>();
+  private context: AudioContext | null = null;
+
+  public constructor() {
+    if (import.meta.hot) {
+      import.meta.hot.on(
+        'canvas-commons:assets',
+        ({urls}: {urls: string[]}) => {
+          for (const url of urls) {
+            this.cache.delete(url);
+          }
+        },
+      );
+    }
+  }
+
+  private entryFor(source: string): CacheEntry {
+    let entry = this.cache.get(source);
+    if (!entry) {
+      entry = {decoded: this.decode(source)};
+      this.cache.set(source, entry);
+    }
+    return entry;
+  }
+
+  /**
+   * Determine whether a source has an audible audio track.
+   *
+   * @remarks
+   * Returns `false` both when the source has no decodable audio track (e.g. a
+   * video encoded without an audio stream) and when the track carries no
+   * audible signal (e.g. a muxed-in silent audio stream), since neither
+   * should produce a waveform in the timeline.
+   *
+   * @param source - URL of the audio/video file to inspect.
+   */
+  public async hasAudio(source: string): Promise<boolean> {
+    const decoded = await this.entryFor(source).decoded;
+    return decoded !== null && decoded.peakAmplitude >= SILENCE_PEAK_THRESHOLD;
+  }
+
+  private getContext(): AudioContext {
+    this.context ??= new AudioContext();
+    return this.context;
+  }
+
+  private async decode(source: string): Promise<DecodedAudio | null> {
+    let response: Response;
+    try {
+      response = await fetch(viaProxy(source));
+    } catch (e: any) {
+      useLogger().warn({
+        message: `Could not fetch audio for analysis: "${source}".`,
+        remarks: String(e),
+      });
+      return null;
+    }
+    if (!response.ok) {
+      useLogger().warn(
+        `Could not fetch audio for analysis: "${source}" (${response.status}).`,
+      );
+      return null;
+    }
+
+    const buffer = await response.arrayBuffer();
+    let audioBuffer: AudioBuffer;
+    try {
+      audioBuffer = await this.getContext().decodeAudioData(buffer);
+    } catch {
+      // No decodable audio track (e.g. a video with no audio stream).
+      return null;
+    }
+
+    const channels: Float32Array[] = [];
+    let peakAmplitude = 0;
+    for (let i = 0; i < audioBuffer.numberOfChannels; i++) {
+      const channel = audioBuffer.getChannelData(i);
+      channels.push(channel);
+      for (let s = 0; s < channel.length; s++) {
+        const magnitude = Math.abs(channel[s]);
+        if (magnitude > peakAmplitude) {
+          peakAmplitude = magnitude;
+        }
+      }
+    }
+
+    return {channels, sampleRate: audioBuffer.sampleRate, peakAmplitude};
+  }
+}
+
+let SharedAnalyzer: MediaAudioAnalyzer | null = null;
+
+/**
+ * Get the shared {@link MediaAudioAnalyzer} instance.
+ *
+ * @remarks
+ * Shared across the whole app so the decode cache is reused between e.g.
+ * `Video` nodes and any UI that inspects a clip's audio.
+ */
+export function useMediaAudioAnalyzer(): MediaAudioAnalyzer {
+  SharedAnalyzer ??= new MediaAudioAnalyzer();
+  return SharedAnalyzer;
+}

--- a/packages/core/src/media/gain.ts
+++ b/packages/core/src/media/gain.ts
@@ -1,0 +1,15 @@
+/**
+ * Convert a decibel value to a linear amplitude gain factor.
+ */
+export function dbToGain(db: number): number {
+  return Math.pow(10, db / 20);
+}
+/**
+ * Convert a linear amplitude gain factor to decibels.
+ *
+ * @remarks
+ * The inverse of {@link dbToGain}. `gain <= 0` maps to `-Infinity` (silence).
+ */
+export function gainToDb(gain: number): number {
+  return gain <= 0 ? -Infinity : 20 * Math.log10(gain);
+}

--- a/packages/core/src/media/index.ts
+++ b/packages/core/src/media/index.ts
@@ -8,4 +8,6 @@ export * from './AudioData';
 export * from './AudioManager';
 export * from './AudioManagerPool';
 export * from './AudioResourceManager';
+export * from './gain';
 export * from './loadImage';
+export * from './MediaAudioAnalyzer';

--- a/packages/core/src/scenes/GeneratorScene.ts
+++ b/packages/core/src/scenes/GeneratorScene.ts
@@ -124,6 +124,8 @@ export abstract class GeneratorScene<T>
   private runner: ThreadGenerator | null = null;
   private state: SceneState = SceneState.Initial;
   private cached = false;
+  private recalculating = false;
+  private recalcHadPendingResources = false;
   private counters: Record<string, number> = {};
   private size: Vector2;
 
@@ -207,7 +209,8 @@ export abstract class GeneratorScene<T>
 
   public async recalculate(setFrame: (frame: number) => void) {
     const cached = this.cache.current;
-    cached.firstFrame = this.playback.frame;
+    const firstFrame = this.playback.frame;
+    cached.firstFrame = firstFrame;
     cached.lastFrame = cached.firstFrame + cached.duration;
 
     if (this.isCached()) {
@@ -216,17 +219,43 @@ export abstract class GeneratorScene<T>
       return;
     }
 
-    cached.transitionDuration = -1;
-    await this.reset();
-    while (!this.canTransitionOut()) {
-      if (
-        cached.transitionDuration < 0 &&
-        this.state === SceneState.AfterTransitionIn
-      ) {
-        cached.transitionDuration = this.playback.frame - cached.firstFrame;
+    // A scene may read an async property (e.g. a video's duration) before the
+    // underlying resource finished loading, giving a not-yet-ready value that
+    // would otherwise be baked into the timeline. When that happens, retry the
+    // pass a bounded number of times so the resolved value is picked up,
+    // instead of caching a degenerate (e.g. zero-length) duration.
+    //
+    // The limit is generous: several large media sources loading their
+    // metadata over a slow connection may each need their own pass to settle,
+    // and giving up early would bake in a truncated timeline.
+    const maxAttempts = 50;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      this.recalcHadPendingResources = false;
+      this.recalculating = true;
+      try {
+        cached.firstFrame = firstFrame;
+        setFrame(firstFrame);
+        cached.transitionDuration = -1;
+        await this.reset();
+        while (!this.canTransitionOut()) {
+          if (
+            cached.transitionDuration < 0 &&
+            this.state === SceneState.AfterTransitionIn
+          ) {
+            cached.transitionDuration = this.playback.frame - cached.firstFrame;
+          }
+          setFrame(this.playback.frame + 1);
+          await this.next();
+        }
+      } finally {
+        this.recalculating = false;
       }
-      setFrame(this.playback.frame + 1);
-      await this.next();
+
+      if (!this.recalcHadPendingResources) {
+        break;
+      }
+      // Give the pending resources a chance to settle before retrying.
+      await DependencyContext.consumePromises();
     }
 
     if (cached.transitionDuration === -1) {
@@ -268,13 +297,22 @@ export abstract class GeneratorScene<T>
 
     if (DependencyContext.hasPromises()) {
       const promises = await DependencyContext.consumePromises();
-      this.logger.error({
-        message:
-          'Tried to access an asynchronous property before the node was ready. ' +
-          'Make sure to yield the node before accessing the property.',
-        stack: promises[0].stack,
-        inspect: promises[0].owner?.key ?? undefined,
-      });
+      // A pending resource here means a property was read before it finished
+      // loading (e.g. a video's duration before its metadata arrived). During
+      // recalculation this is expected and recoverable: the value resolves
+      // asynchronously, so flag it for a retry instead of reporting an error
+      // and baking in the not-yet-ready value.
+      if (this.recalculating) {
+        this.recalcHadPendingResources = true;
+      } else {
+        this.logger.error({
+          message:
+            'Tried to access an asynchronous property before the node was ready. ' +
+            'Make sure to yield the node before accessing the property.',
+          stack: promises[0].stack,
+          inspect: promises[0].owner?.key ?? undefined,
+        });
+      }
     }
 
     if (result.done) {

--- a/packages/core/src/scenes/NodeInspection.ts
+++ b/packages/core/src/scenes/NodeInspection.ts
@@ -1,0 +1,9 @@
+/**
+ * `Inspection.key` used to inspect an individual scene-graph node.
+ *
+ * @remarks
+ * Defined in `core` (rather than `2d`, where the node inspector itself
+ * lives) so other packages that can't depend on `2d` - like `editor`'s
+ * timeline - can still set/read this to link UI back to a specific node.
+ */
+export const NODE_INSPECTOR_KEY = '@canvas-commons/2d/node-inspector';

--- a/packages/core/src/scenes/Sounds.test.ts
+++ b/packages/core/src/scenes/Sounds.test.ts
@@ -1,0 +1,94 @@
+import {describe, expect, it, vi} from 'vitest';
+import type {Scene} from './Scene';
+import {Sounds} from './Sounds';
+
+function createSounds(): {sounds: Sounds; recalculate: () => void} {
+  const subscribable = {subscribe: vi.fn(() => () => {})};
+  let recalcHandler: (() => void) | null = null;
+  const scene = {
+    onReset: subscribable,
+    onReloaded: subscribable,
+    onRecalculated: {
+      subscribe: vi.fn((handler: () => void) => {
+        recalcHandler = handler;
+        return () => {};
+      }),
+    },
+    playback: {time: 0},
+  } as unknown as Scene;
+  return {sounds: new Sounds(scene), recalculate: () => recalcHandler?.()};
+}
+
+describe('Sounds', () => {
+  it('notifies subscribers when a sound is added via recalculation', () => {
+    const {sounds, recalculate} = createSounds();
+    const handler = vi.fn();
+    sounds.onChanged.subscribe(handler, false);
+
+    sounds.add({audio: 'a.mp3'});
+    expect(sounds.getSounds()).toHaveLength(1);
+
+    recalculate();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults origin to audio for keyless sounds and media for keyed ones', () => {
+    const {sounds} = createSounds();
+    const plain = sounds.add({audio: 'a.mp3'});
+    const keyed = sounds.add({audio: 'b.mp3', sourceKey: 'video-1'});
+    const explicit = sounds.add({
+      audio: 'c.mp3',
+      sourceKey: 'audio-1',
+      origin: 'audio',
+    });
+
+    expect(plain.origin).toBe('audio');
+    expect(keyed.origin).toBe('media');
+    expect(explicit.origin).toBe('audio');
+  });
+
+  it('drops a broadcast sound from the list when it is removed', () => {
+    const {sounds, recalculate} = createSounds();
+    const clip = sounds.add({audio: 'a.mp3', sourceKey: 'video-1'});
+    // Recalculation is what publishes the list the editor renders; a later
+    // async removal (e.g. a silent clip) must then drop it.
+    recalculate();
+
+    const handler = vi.fn();
+    sounds.onChanged.subscribe(handler, false);
+
+    sounds.remove(clip);
+
+    expect(sounds.getSounds()).toHaveLength(0);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenLastCalledWith([]);
+  });
+
+  it('keeps the broadcast list intact when removing a never-published sound', () => {
+    const {sounds, recalculate} = createSounds();
+    const published = sounds.add({audio: 'published.mp3', sourceKey: 'a'});
+    recalculate();
+
+    // A sound registered after the last recalculation (e.g. during live
+    // playback, when the scene re-executes frame by frame) is not part of the
+    // published list, so removing it must not disturb what the editor shows.
+    const live = sounds.add({audio: 'live.mp3', sourceKey: 'b'});
+    const handler = vi.fn();
+    sounds.onChanged.subscribe(handler, false);
+
+    sounds.remove(live);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(sounds.onChanged.current).toContain(published);
+  });
+
+  it('does not notify when removing an unknown sound', () => {
+    const {sounds} = createSounds();
+    const handler = vi.fn();
+    sounds.onChanged.subscribe(handler, false);
+
+    sounds.remove({audio: 'ghost.mp3'} as never);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/scenes/Sounds.ts
+++ b/packages/core/src/scenes/Sounds.ts
@@ -2,6 +2,17 @@ import {ValueDispatcher} from '../events';
 import {useScene} from '../utils';
 import type {Scene} from './Scene';
 
+/**
+ * Where a registered sound came from.
+ *
+ * @remarks
+ * - `media`: embedded audio of a visual media node (e.g. `Video`). Rendered on
+ *   the auto-populated media-audio lane, always tied to its source node.
+ * - `audio`: a project audio clip authored via the `Audio` node. Rendered on a
+ *   user-managed project audio track, movable between tracks in the editor.
+ */
+export type SoundOrigin = 'media' | 'audio';
+
 export interface SoundSettings {
   audio: string;
   start?: number;
@@ -9,6 +20,26 @@ export interface SoundSettings {
   gain?: number;
   detune?: number;
   playbackRate?: number;
+  /**
+   * The key of the scene node this sound originated from, if any.
+   *
+   * @remarks
+   * Set by `Video`/`Audio` when they register their audio as a `Sound`. Lets
+   * the timeline group/link clips back to the node that produced them, and
+   * gives the editor a stable id to persist per-clip track assignments
+   * against. Sounds registered directly via `sound()` have no key.
+   */
+  sourceKey?: string;
+  /**
+   * Which timeline lane family this sound belongs to.
+   *
+   * @remarks
+   * Distinguishes auto-populated media audio (`media`) from user-editable
+   * project audio (`audio`). Sounds registered via `sound()` default to
+   * `audio`. Absent on legacy clips, treated as `media` when a `sourceKey` is
+   * present (old `Video` behaviour) and `audio` otherwise.
+   */
+  origin?: SoundOrigin;
 }
 
 export interface Sound extends SoundSettings {
@@ -83,8 +114,8 @@ export class SoundBuilder {
    *
    * @param offset - An offset in seconds from the current frame. Defaults to 0.
    */
-  public play(offset?: number) {
-    useScene().sounds.add(this.settings, offset);
+  public play(offset?: number): Sound {
+    return useScene().sounds.add(this.settings, offset);
   }
 }
 
@@ -108,16 +139,56 @@ export class Sounds {
     this.scene.onRecalculated.subscribe(this.handleRecalculated);
   }
 
-  public add(settings: SoundSettings, offset?: number) {
+  /**
+   * Register a sound to be played back.
+   *
+   * @remarks
+   * Returns the registered {@link Sound} by reference, which callers may
+   * mutate afterwards (e.g. to set `end` once a media clip stops playing, or
+   * to apply a loudness-normalization gain once it has been measured
+   * asynchronously).
+   */
+  public add(settings: SoundSettings, offset?: number): Sound {
     const playbackTime = this.scene.playback.time + (offset ?? 0);
 
-    this.registeredSounds.push({
+    const registered: Sound = {
       offset: playbackTime,
       realPlaybackRate:
         Math.pow(2, (settings.detune ?? 0) / 1200) *
         (settings.playbackRate ?? 1),
       ...settings,
-    });
+      origin: settings.origin ?? (settings.sourceKey ? 'media' : 'audio'),
+    };
+    this.registeredSounds.push(registered);
+    return registered;
+  }
+
+  /**
+   * Unregister a previously added sound.
+   *
+   * @remarks
+   * Used to discard a sound that turned out not to be playable (e.g. a media
+   * clip whose source has no audio track).
+   */
+  public remove(sound: Sound) {
+    const index = this.registeredSounds.indexOf(sound);
+    if (index !== -1) {
+      this.registeredSounds.splice(index, 1);
+    }
+
+    // Drop the sound from the broadcast list too, but by reference rather than
+    // rebuilding it from `registeredSounds`. During live playback the scene
+    // re-executes frame by frame, so `registeredSounds` is only partially
+    // rebuilt at any given moment; rebuilding the broadcast from it would make
+    // the timeline lose every clip past the playhead. Removing just this
+    // sound keeps the rest of the (recalculated) list intact, which still
+    // drops the box for a silent clip whose async audio check just resolved.
+    const broadcastIndex = this.sounds.current.indexOf(sound);
+    if (broadcastIndex !== -1) {
+      const next = [...this.sounds.current];
+      next.splice(broadcastIndex, 1);
+      this.sounds.current = next;
+    }
   }
 
   public getSounds(): readonly Sound[] {

--- a/packages/core/src/scenes/index.ts
+++ b/packages/core/src/scenes/index.ts
@@ -7,6 +7,7 @@
 export * from './GeneratorScene';
 export * from './Inspectable';
 export * from './LifecycleEvents';
+export * from './NodeInspection';
 export * from './Random';
 export * from './Scene';
 export * from './SceneMetadata';

--- a/packages/core/src/scenes/timeEvents/ReadOnlyTimeEvents.test.ts
+++ b/packages/core/src/scenes/timeEvents/ReadOnlyTimeEvents.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it} from 'vitest';
+import {EventDispatcher} from '../../events';
+import type {Scene} from '../Scene';
+import {ReadOnlyTimeEvents} from './ReadOnlyTimeEvents';
+import type {SerializedTimeEvent} from './SerializedTimeEvent';
+
+function mockScene(events: SerializedTimeEvent[]): Scene {
+  return {
+    onReloaded: new EventDispatcher<void>(),
+    meta: {
+      timeEvents: {
+        get: () => events,
+      },
+    },
+  } as unknown as Scene;
+}
+
+describe('ReadOnlyTimeEvents', () => {
+  it('returns the stored duration for an event reached at its initial time', () => {
+    const scene = mockScene([{name: 'event', targetTime: 5}]);
+    const timeEvents = new ReadOnlyTimeEvents(scene);
+    expect(timeEvents.register('event', 0)).toBe(5);
+  });
+
+  it('clamps a negative duration to zero', () => {
+    // A stored targetTime earlier than where the event is registered would
+    // otherwise rewind the timeline and collapse the scene duration.
+    const scene = mockScene([{name: 'event', targetTime: 0}]);
+    const timeEvents = new ReadOnlyTimeEvents(scene);
+    expect(timeEvents.register('event', 96)).toBe(0);
+  });
+
+  it('returns zero for an unknown event', () => {
+    const scene = mockScene([]);
+    const timeEvents = new ReadOnlyTimeEvents(scene);
+    expect(timeEvents.register('missing', 10)).toBe(0);
+  });
+
+  it('caches the duration on first lookup', () => {
+    const scene = mockScene([{name: 'event', targetTime: 8}]);
+    const timeEvents = new ReadOnlyTimeEvents(scene);
+    expect(timeEvents.register('event', 0)).toBe(8);
+    // A later registration at a different time reuses the cached value.
+    expect(timeEvents.register('event', 100)).toBe(8);
+  });
+});

--- a/packages/core/src/scenes/timeEvents/ReadOnlyTimeEvents.ts
+++ b/packages/core/src/scenes/timeEvents/ReadOnlyTimeEvents.ts
@@ -27,7 +27,12 @@ export class ReadOnlyTimeEvents implements TimeEvents {
       const event = this.scene.meta.timeEvents
         .get()
         .find(event => event.name === name);
-      duration = event ? event.targetTime - initialTime : 0;
+      // Clamp to a non-negative wait, mirroring EditableTimeEvents. A stored
+      // `targetTime` earlier than where the event is reached (e.g. an event
+      // left at 0 that is now registered later in the timeline) would otherwise
+      // yield a negative duration, which rewinds the thread time and collapses
+      // the scene's computed length during rendering.
+      duration = event ? Math.max(0, event.targetTime - initialTime) : 0;
       this.lookup.set(name, duration);
     }
 

--- a/packages/core/src/signals/DependencyContext.ts
+++ b/packages/core/src/signals/DependencyContext.ts
@@ -48,6 +48,25 @@ export class DependencyContext<TOwner = void> implements Promisable<
     return this.promises.length > 0;
   }
 
+  /**
+   * Run `callback`, discarding any promises it collects instead of tracking
+   * them for the scene.
+   *
+   * @remarks
+   * Used when a value must be read from teardown paths (e.g. disposing a
+   * node) where an unresolved async property should not be reported as
+   * "accessed before the node was ready". Promises collected before the
+   * callback are preserved.
+   */
+  public static collectingPromisesSuppressed<T>(callback: () => T): T {
+    const mark = this.promises.length;
+    try {
+      return callback();
+    } finally {
+      this.promises.length = mark;
+    }
+  }
+
   public static async consumePromises() {
     const promises = [...this.promises];
     await Promise.all(promises.map(handle => handle.promise));

--- a/packages/editor/src/components/icons/ChevronLeft.tsx
+++ b/packages/editor/src/components/icons/ChevronLeft.tsx
@@ -1,0 +1,9 @@
+import {HTMLAttributes} from 'preact/compat';
+
+export function ChevronLeft(props: HTMLAttributes<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+      <polygon points="13.29 16.71 8.59 12 13.29 7.29 14.71 8.71 11.41 12 14.71 15.29 13.29 16.71" />
+    </svg>
+  );
+}

--- a/packages/editor/src/components/timeline/AudioTrack.tsx
+++ b/packages/editor/src/components/timeline/AudioTrack.tsx
@@ -6,8 +6,7 @@ import {useApplication, useModifiers, useTimelineContext} from '../../contexts';
 import {useScenes, useSharedSettings, useSubscribableValue} from '../../hooks';
 import {MouseButton} from '../../utils';
 import styles from './Timeline.module.scss';
-
-const HEIGHT = 48;
+import {DEFAULT_WAVE_HEIGHT} from './trackLayout';
 
 export function AudioTrack() {
   const scenes = useScenes();
@@ -84,8 +83,7 @@ function MainAudioClip() {
     )
   );
 }
-
-interface AudioClipProps extends JSX.HTMLAttributes<HTMLDivElement> {
+export interface AudioClipProps extends JSX.HTMLAttributes<HTMLDivElement> {
   audio: string;
   offset: number;
   start?: number;
@@ -94,6 +92,24 @@ interface AudioClipProps extends JSX.HTMLAttributes<HTMLDivElement> {
   hoverable?: boolean;
   editable?: boolean;
   disabled?: boolean;
+  /** Overrides the waveform color (defaults to white). */
+  color?: string;
+  /** Dims the clip, used to de-emphasize non-hovered overlapping clips. */
+  faded?: boolean;
+  /** Height of the waveform area, set by the lane's resize handle. */
+  height?: number;
+  /**
+   * Stable clip id, enabling drag-to-another-track. When set the clip becomes
+   * draggable and carries this key so the drop target can reassign it.
+   */
+  draggableKey?: string;
+  // Extra `Sound` fields callers spread in via `{...sound}`; consumed here so
+  // they don't leak onto the DOM element.
+  gain?: number;
+  detune?: number;
+  playbackRate?: number;
+  sourceKey?: string;
+  origin?: 'media' | 'audio';
 }
 
 export function AudioClip({
@@ -104,9 +120,24 @@ export function AudioClip({
   realPlaybackRate = 1,
   hoverable,
   editable,
+  color = '#fff',
+  faded,
+  height = DEFAULT_WAVE_HEIGHT,
+  draggableKey,
+  // Discard non-DOM `Sound` fields spread in via `{...sound}`.
+  gain: _gain,
+  detune: _detune,
+  playbackRate: _playbackRate,
+  sourceKey: _sourceKey,
+  origin: _origin,
+  style,
   className,
+  onPointerDown,
   ...props
 }: AudioClipProps) {
+  // The waveform is drawn symmetrically around a center line, so the canvas
+  // works in half-height units.
+  const halfHeight = height / 2;
   const {player} = useApplication();
   const audioData = useSubscribableValue(
     player.audioResources.get(audio).onData,
@@ -131,8 +162,12 @@ export function AudioClip({
     clipDuration,
     waveformVisible,
   } = useMemo(() => {
+    // A non-finite `end` (e.g. a clip still playing, or one whose stop time
+    // could not be resolved) means "until the source ends", so fall back to
+    // the decoded duration instead of letting NaN collapse the waveform.
+    const clipEndTime = isFinite(end) ? end : audioData.duration;
     const endOffset =
-      (Math.min(audioData.duration, end) - start) / realPlaybackRate;
+      (Math.min(audioData.duration, clipEndTime) - start) / realPlaybackRate;
 
     const clipStart = offset;
     const clipEnd = offset + endOffset;
@@ -173,9 +208,9 @@ export function AudioClip({
 
     const context = contextRef.current;
     if (!context) return;
-    context.clearRect(0, 0, viewLength, HEIGHT * 2);
+    context.clearRect(0, 0, viewLength, height);
     context.beginPath();
-    context.moveTo(0, HEIGHT);
+    context.moveTo(0, halfHeight);
 
     const relativeStartTime =
       (waveformStart - offset) * realPlaybackRate + start;
@@ -196,17 +231,19 @@ export function AudioClip({
 
       context.lineTo(
         ((padding + offset) / length) * waveformWidth,
-        (audioData.peaks[sample] / audioData.absoluteMax) * HEIGHT + HEIGHT,
+        (audioData.peaks[sample] / audioData.absoluteMax) * halfHeight +
+          halfHeight,
       );
       context.lineTo(
         ((padding + offset + step) / length) * waveformWidth,
-        (audioData.peaks[sample + 1] / audioData.absoluteMax) * HEIGHT + HEIGHT,
+        (audioData.peaks[sample + 1] / audioData.absoluteMax) * halfHeight +
+          halfHeight,
       );
     }
 
     context.lineWidth = 1;
     context.lineJoin = 'round';
-    context.strokeStyle = '#fff';
+    context.strokeStyle = color;
     context.stroke();
   }, [
     waveformStart,
@@ -219,6 +256,8 @@ export function AudioClip({
     start,
     audioData,
     realPlaybackRate,
+    color,
+    halfHeight,
   ]);
 
   const [wrapperStyle, canvasStyle] = useMemo(
@@ -226,13 +265,24 @@ export function AudioClip({
       {
         left: `${secondsToPercents(clipStart)}%`,
         width: `${secondsToPercents(clipDuration)}%`,
-        height: `${HEIGHT * 2}px`,
+        height: `${height}px`,
+        opacity: faded ? 0.35 : 1,
+        transition: 'opacity 0.15s ease',
+        ...(typeof style === 'object' ? style : {}),
       },
       {
         left: `${((waveformStart - clipStart) / clipDuration) * 100}%`,
       },
     ],
-    [waveformStart, clipDuration, clipStart, secondsToPercents],
+    [
+      waveformStart,
+      clipDuration,
+      clipStart,
+      secondsToPercents,
+      faded,
+      style,
+      height,
+    ],
   );
 
   return (
@@ -241,21 +291,44 @@ export function AudioClip({
         styles.audioClip,
         hoverable && styles.hoverable,
         editable && styles.editable,
+        draggableKey && styles.draggable,
         className,
       )}
       style={wrapperStyle}
+      draggable={draggableKey !== undefined}
+      onPointerDown={event => {
+        // Keep the press from reaching the timeline surface, which would
+        // otherwise capture the pointer and scrub the playhead - stealing the
+        // gesture before the native drag-and-drop can start. Mirrors how the
+        // timeline Label swallows its own pointerdown. `preventDefault` is
+        // intentionally omitted for draggable clips: it would suppress the
+        // element's `dragstart`. Editable (offset-dragging) clips still get
+        // their own handler via `onPointerDown` below.
+        if (draggableKey !== undefined) {
+          event.stopPropagation();
+        }
+        onPointerDown?.(event);
+      }}
+      onDragStart={
+        draggableKey
+          ? event => {
+              event.dataTransfer?.setData(
+                'application/x-audio-clip',
+                draggableKey,
+              );
+              event.dataTransfer!.effectAllowed = 'move';
+            }
+          : undefined
+      }
       {...props}
     >
-      {hoverable && waveformWidth > 8 && (
-        <div className={styles.audioLabel}>{audio}</div>
-      )}
       {waveformVisible && waveformWidth > 8 && (
         <canvas
           ref={ref}
           style={canvasStyle}
           className={styles.audioCanvas}
           width={Math.round(waveformWidth)}
-          height={HEIGHT * 2}
+          height={height}
         />
       )}
     </div>

--- a/packages/editor/src/components/timeline/AudioTrack.tsx
+++ b/packages/editor/src/components/timeline/AudioTrack.tsx
@@ -6,12 +6,13 @@ import {useApplication, useModifiers, useTimelineContext} from '../../contexts';
 import {useScenes, useSharedSettings, useSubscribableValue} from '../../hooks';
 import {MouseButton} from '../../utils';
 import styles from './Timeline.module.scss';
-import {DEFAULT_WAVE_HEIGHT} from './trackLayout';
+import {DEFAULT_WAVE_HEIGHT, useTrackLayout} from './trackLayout';
 
 export function AudioTrack() {
   const scenes = useScenes();
+  const layoutRef = useTrackLayout<HTMLDivElement>('audio');
   return (
-    <div className={styles.audioTrack}>
+    <div ref={layoutRef} className={styles.projectAudioTrack}>
       <MainAudioClip />
       {scenes.map(scene => (
         <AudioGroup scene={scene} />

--- a/packages/editor/src/components/timeline/AudioTrack.tsx
+++ b/packages/editor/src/components/timeline/AudioTrack.tsx
@@ -6,12 +6,16 @@ import {useApplication, useModifiers, useTimelineContext} from '../../contexts';
 import {useScenes, useSharedSettings, useSubscribableValue} from '../../hooks';
 import {MouseButton} from '../../utils';
 import styles from './Timeline.module.scss';
-import {DEFAULT_WAVE_HEIGHT, useTrackLayout} from './trackLayout';
+import {
+  DEFAULT_WAVE_HEIGHT,
+  useTrackLayout,
+  useWaveHeight,
+} from './trackLayout';
 
 export function AudioTrack() {
   const scenes = useScenes();
   const layoutRef = useTrackLayout<HTMLDivElement>('audio');
-  const height = DEFAULT_WAVE_HEIGHT;
+  const {height} = useWaveHeight('audio');
   return (
     <div
       ref={layoutRef}
@@ -33,9 +37,15 @@ interface AudioGroupProps {
 
 export function AudioGroup({scene, height}: AudioGroupProps) {
   const sounds = useSubscribableValue(scene.sounds.onChanged);
+  // Media audio (embedded in Video nodes) has its own lane; the project audio
+  // track only shows user-authored sounds.
+  const projectSounds = sounds.filter(sound => {
+    const origin = sound.origin ?? (sound.sourceKey ? 'media' : 'audio');
+    return origin === 'audio';
+  });
   return (
     <>
-      {sounds.map(sound => (
+      {projectSounds.map(sound => (
         <AudioClip hoverable height={height} {...sound} />
       ))}
     </>

--- a/packages/editor/src/components/timeline/AudioTrack.tsx
+++ b/packages/editor/src/components/timeline/AudioTrack.tsx
@@ -11,11 +11,16 @@ import {DEFAULT_WAVE_HEIGHT, useTrackLayout} from './trackLayout';
 export function AudioTrack() {
   const scenes = useScenes();
   const layoutRef = useTrackLayout<HTMLDivElement>('audio');
+  const height = DEFAULT_WAVE_HEIGHT;
   return (
-    <div ref={layoutRef} className={styles.projectAudioTrack}>
-      <MainAudioClip />
+    <div
+      ref={layoutRef}
+      className={styles.projectAudioTrack}
+      style={{height: `${height}px`}}
+    >
+      <MainAudioClip height={height} />
       {scenes.map(scene => (
-        <AudioGroup scene={scene} />
+        <AudioGroup scene={scene} height={height} />
       ))}
     </div>
   );
@@ -23,20 +28,21 @@ export function AudioTrack() {
 
 interface AudioGroupProps {
   scene: Scene;
+  height: number;
 }
 
-export function AudioGroup({scene}: AudioGroupProps) {
+export function AudioGroup({scene, height}: AudioGroupProps) {
   const sounds = useSubscribableValue(scene.sounds.onChanged);
   return (
     <>
       {sounds.map(sound => (
-        <AudioClip hoverable {...sound} />
+        <AudioClip hoverable height={height} {...sound} />
       ))}
     </>
   );
 }
 
-function MainAudioClip() {
+function MainAudioClip({height}: {height: number}) {
   const {player, meta} = useApplication();
   const source = player.audio.getSource();
   const {audioOffset} = useSharedSettings();
@@ -58,6 +64,7 @@ function MainAudioClip() {
         editable={active || isEditing}
         audio={source}
         offset={fullOffset}
+        height={height}
         disabled
         onPointerDown={e => {
           if (active && e.button === MouseButton.Left) {

--- a/packages/editor/src/components/timeline/LabelTrack.tsx
+++ b/packages/editor/src/components/timeline/LabelTrack.tsx
@@ -2,12 +2,14 @@ import styles from './Timeline.module.scss';
 
 import {useScenes} from '../../hooks';
 import {LabelGroup} from './LabelGroup';
+import {useTrackLayout} from './trackLayout';
 
 export function LabelTrack() {
   const scenes = useScenes();
+  const layoutRef = useTrackLayout<HTMLDivElement>('label');
 
   return (
-    <div className={styles.labelTrack}>
+    <div ref={layoutRef} className={styles.labelTrack}>
       {scenes.map(scene => (
         <LabelGroup key={scene.name} scene={scene} />
       ))}

--- a/packages/editor/src/components/timeline/MediaAudioTrack.tsx
+++ b/packages/editor/src/components/timeline/MediaAudioTrack.tsx
@@ -1,0 +1,68 @@
+import {NODE_INSPECTOR_KEY} from '@canvas-commons/core';
+import {useState} from 'preact/hooks';
+import {useApplication} from '../../contexts';
+import {useScenes} from '../../hooks';
+import {AudioClip} from './AudioTrack';
+import {colorForKey, useMediaSounds} from './mediaSounds';
+import styles from './Timeline.module.scss';
+import {useTrackLayout, useWaveHeight} from './trackLayout';
+
+/**
+ * Timeline lane for audio embedded in media (`Video`) nodes.
+ *
+ * @remarks
+ * Unlike project audio tracks, this lane is auto-populated from scene
+ * content rather than user-organized, so all clips share a single lane.
+ * Overlapping clips (e.g. two videos playing at once) are distinguished by a
+ * per-source color and a hover-to-isolate interaction instead of being split
+ * into separate generated lanes, which would make the timeline's layout
+ * unstable.
+ *
+ * Renders nothing (not even an empty reserved lane) when the project has no
+ * media audio, which is the common case - most projects only use the
+ * project audio track below.
+ */
+export function MediaAudioTrack() {
+  const scenes = useScenes();
+  const {inspection} = useApplication();
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  const mediaSounds = useMediaSounds(scenes);
+  const layoutRef = useTrackLayout<HTMLDivElement>('media');
+  const {height} = useWaveHeight('media');
+
+  const selectedKey =
+    inspection.value.key === NODE_INSPECTOR_KEY
+      ? ((inspection.value.payload as string | null) ?? null)
+      : null;
+  const activeKey = hoveredKey ?? selectedKey;
+
+  if (mediaSounds.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={layoutRef}
+      className={styles.audioTrack}
+      style={{height: `${height}px`}}
+    >
+      {mediaSounds.map(sound => (
+        <AudioClip
+          hoverable
+          height={height}
+          {...sound}
+          color={colorForKey(sound.sourceKey)}
+          faded={activeKey !== null && activeKey !== sound.sourceKey}
+          onPointerEnter={() => setHoveredKey(sound.sourceKey)}
+          onPointerLeave={() => setHoveredKey(null)}
+          onClick={() => {
+            inspection.value = {
+              key: NODE_INSPECTOR_KEY,
+              payload: sound.sourceKey,
+            };
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/editor/src/components/timeline/RangeSelector.tsx
+++ b/packages/editor/src/components/timeline/RangeSelector.tsx
@@ -9,6 +9,7 @@ import {useDuration, usePreviewSettings, useSharedSettings} from '../../hooks';
 import {labelClipDraggingLeftSignal} from '../../signals';
 import {MouseButton} from '../../utils';
 import {DragIndicator} from '../icons';
+import {useTrackLayout} from './trackLayout';
 
 export interface RangeSelectorProps {
   rangeRef: RefObject<HTMLDivElement>;
@@ -26,6 +27,7 @@ export function RangeSelector({rangeRef}: RangeSelectorProps) {
   const [start, setStart] = useState(startFrame);
   const [end, setEnd] = useState(endFrame);
   const modifiers = useModifiers();
+  const layoutRef = useTrackLayout<HTMLDivElement>('range');
 
   const onDrop = useCallback(() => {
     labelClipDraggingLeftSignal.value = null;
@@ -46,6 +48,7 @@ export function RangeSelector({rangeRef}: RangeSelectorProps) {
 
   return (
     <div
+      ref={layoutRef}
       className={clsx(
         styles.rangeTrack,
         modifiers.value.shift && modifiers.value.ctrl && styles.active,

--- a/packages/editor/src/components/timeline/SceneTrack.tsx
+++ b/packages/editor/src/components/timeline/SceneTrack.tsx
@@ -6,12 +6,14 @@ import {useApplication, useTimelineContext} from '../../contexts';
 import {useScenes, useSubscribableValue} from '../../hooks';
 import {findAndOpenFirstUserFile} from '../../utils';
 import {SlideTrack} from './SlideTrack';
+import {useTrackLayout} from './trackLayout';
 
 export function SceneTrack() {
   const scenes = useScenes();
+  const layoutRef = useTrackLayout<HTMLDivElement>('scene');
 
   return (
-    <div className={styles.sceneTrack}>
+    <div ref={layoutRef} className={styles.sceneTrack}>
       {scenes.map(scene => (
         <SceneClip scene={scene} />
       ))}

--- a/packages/editor/src/components/timeline/Timeline.module.scss
+++ b/packages/editor/src/components/timeline/Timeline.module.scss
@@ -330,14 +330,14 @@
   flex-shrink: 1;
 }
 
+// Height is set inline from the lane's resize handle.
 .audioTrack {
   position: relative;
-  height: calc(96px + 32px * 2);
-  padding: 32px 0;
 }
 
 .audioClip {
   position: absolute;
+  top: 0;
 
   &.hoverable {
     border-radius: var(--radius);
@@ -351,10 +351,6 @@
 
       .audioCanvas {
         filter: brightness(0.54);
-      }
-
-      .audioLabel {
-        background-color: var(--surface-color-light);
       }
     }
   }
@@ -371,6 +367,14 @@
       filter: brightness(0.36);
     }
   }
+
+  &.draggable {
+    cursor: grab;
+
+    &:active {
+      cursor: grabbing;
+    }
+  }
 }
 
 .audioCanvas {
@@ -378,14 +382,4 @@
   top: 0;
   bottom: 0;
   filter: brightness(0.27);
-}
-
-.audioLabel {
-  position: absolute;
-  bottom: 100%;
-  cursor: default;
-  border-radius: 12px 12px 12px 0;
-  translate: 0 2px;
-  padding: 0 8px;
-  background-color: var(--surface-color-hover);
 }

--- a/packages/editor/src/components/timeline/Timeline.module.scss
+++ b/packages/editor/src/components/timeline/Timeline.module.scss
@@ -448,6 +448,12 @@
   position: relative;
 }
 
+.projectAudioTrack {
+  position: relative;
+  height: calc(96px + 32px * 2);
+  padding: 32px 0;
+}
+
 .audioClip {
   position: absolute;
   top: 0;

--- a/packages/editor/src/components/timeline/Timeline.module.scss
+++ b/packages/editor/src/components/timeline/Timeline.module.scss
@@ -107,6 +107,45 @@
   color: rgba(255, 255, 255, 0.72);
 }
 
+.trackButtons {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.trackButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-family: var(--font-family);
+  font-size: var(--font-size-small);
+  font-weight: bold;
+  line-height: 1;
+  background-color: var(--surface-color-hover);
+  color: rgba(255, 255, 255, 0.54);
+
+  &:hover {
+    background-color: var(--surface-color-light);
+    color: #fff;
+  }
+
+  &.trackButtonActive {
+    background-color: var(--theme);
+    color: #000;
+  }
+}
+
+.trackIconButton > svg {
+  width: 14px;
+  height: 14px;
+}
+
 .trackResize {
   position: absolute;
   left: 0;
@@ -450,8 +489,6 @@
 
 .projectAudioTrack {
   position: relative;
-  height: calc(96px + 32px * 2);
-  padding: 32px 0;
 }
 
 .audioClip {

--- a/packages/editor/src/components/timeline/Timeline.module.scss
+++ b/packages/editor/src/components/timeline/Timeline.module.scss
@@ -15,14 +15,127 @@
 }
 
 .sidebar {
-  width: 320px;
+  width: 200px;
   flex-shrink: 0;
   flex-grow: 0;
+  overflow: hidden;
+  position: relative;
+  background-color: var(--surface-color);
+  border-right: 1px solid var(--border-color);
+  z-index: 2;
+
+  &.collapsed {
+    width: 28px;
+  }
+}
+
+// Mirrors the lane area's vertical scroll so rows stay next to their lanes.
+.sidebarRows {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+
+.sidebarToggle {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius);
+  cursor: pointer;
+  background-color: var(--surface-color-hover);
+  color: rgba(255, 255, 255, 0.54);
+
+  &:hover {
+    background-color: var(--surface-color-light);
+    color: #fff;
+  }
+
+  > svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.trackHeader {
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+  border-top: 1px solid var(--border-color);
+  background-color: var(--surface-color-hover);
+}
+
+.trackAccent {
+  width: 3px;
+  flex-shrink: 0;
+}
+
+.trackHeaderBody {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px 8px;
+  min-width: 0;
+  flex-grow: 1;
+}
+
+.trackHeaderTop {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.trackName {
+  flex-grow: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--font-size-small);
+  line-height: 20px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.trackResize {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 6px;
+  cursor: ns-resize;
+  touch-action: none;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    top: 2px;
+    height: 2px;
+    border-radius: 1px;
+    background-color: transparent;
+  }
+
+  &:hover::after,
+  &:active::after {
+    background-color: var(--theme);
+  }
 }
 
 .timelineWrapper {
   overflow-x: scroll;
-  overflow-y: hidden;
+  overflow-y: auto;
   flex-grow: 1;
   position: relative;
   background-color: var(--background-color);
@@ -32,13 +145,13 @@
 .timeline {
   position: relative;
   overflow: hidden;
-  height: 100%;
+  min-height: 100%;
 }
 
 .timelineContent {
   position: relative;
   overflow: visible;
-  height: 100%;
+  min-height: 100%;
 }
 
 .trackContainer {

--- a/packages/editor/src/components/timeline/Timeline.tsx
+++ b/packages/editor/src/components/timeline/Timeline.tsx
@@ -32,6 +32,7 @@ import {RangeSelector} from './RangeSelector';
 import {SceneTrack} from './SceneTrack';
 import {Timestamps} from './Timestamps';
 import {TrackLayoutProvider, useTrackScrollTop} from './trackLayout';
+import {TrackSidebar} from './TrackSidebar';
 
 const ZOOM_SPEED = 0.1;
 const ZOOM_MIN = 0.5;
@@ -213,12 +214,27 @@ function TimelineContent() {
     }
   };
 
+  // The sidebar sits outside the scrolling lane area, so wheeling over it
+  // has to be forwarded to keep the two columns moving together.
+  const scrollLanes = (event: WheelEvent) => {
+    const container = containerRef.current;
+    if (!container) return;
+    event.preventDefault();
+    container.scrollTop = clamp(
+      0,
+      container.scrollHeight - container.clientHeight,
+      container.scrollTop + event.deltaY,
+    );
+    trackScrollTop.value = container.scrollTop;
+  };
+
   return (
     <TimelineContextProvider state={state}>
       <div
         ref={shortcutRef}
         className={clsx(styles.root, isReady && styles.show)}
       >
+        <TrackSidebar onWheel={scrollLanes} />
         <div
           className={styles.timelineWrapper}
           ref={containerRef}

--- a/packages/editor/src/components/timeline/Timeline.tsx
+++ b/packages/editor/src/components/timeline/Timeline.tsx
@@ -26,10 +26,12 @@ import {MouseButton, MouseMask, clamp} from '../../utils';
 import {borderHighlight} from '../animations';
 import {AudioTrack} from './AudioTrack';
 import {LabelTrack} from './LabelTrack';
+import {MediaAudioTrack} from './MediaAudioTrack';
 import {Playhead} from './Playhead';
 import {RangeSelector} from './RangeSelector';
 import {SceneTrack} from './SceneTrack';
 import {Timestamps} from './Timestamps';
+import {TrackLayoutProvider, useTrackScrollTop} from './trackLayout';
 
 const ZOOM_SPEED = 0.1;
 const ZOOM_MIN = 0.5;
@@ -38,7 +40,16 @@ const VIRTUAL_SCROLL_SPACING = 256;
 const MAX_FRAME_SIZE = 128;
 
 export function Timeline() {
+  return (
+    <TrackLayoutProvider>
+      <TimelineContent />
+    </TrackLayoutProvider>
+  );
+}
+
+function TimelineContent() {
   const shortcutRef = useSurfaceShortcuts<HTMLDivElement>(TIMELINE_SHORTCUTS);
+  const trackScrollTop = useTrackScrollTop();
   const {player, meta} = useApplication();
   const {range} = useSharedSettings();
   const containerRef = useRef<HTMLDivElement>();
@@ -211,9 +222,11 @@ export function Timeline() {
         <div
           className={styles.timelineWrapper}
           ref={containerRef}
-          onScroll={event =>
-            setOffset((event.target as HTMLElement).scrollLeft)
-          }
+          onScroll={event => {
+            const target = event.target as HTMLElement;
+            setOffset(target.scrollLeft);
+            trackScrollTop.value = target.scrollTop;
+          }}
           onWheel={event => {
             const isVertical = Math.abs(event.deltaX) > Math.abs(event.deltaY);
             if (event.shiftKey || isVertical) return;
@@ -315,6 +328,7 @@ export function Timeline() {
                 <SceneTrack />
                 <LabelTrack />
                 <AudioTrack />
+                <MediaAudioTrack />
               </div>
               <Playhead seeking={seeking} />
             </div>

--- a/packages/editor/src/components/timeline/TrackSidebar.tsx
+++ b/packages/editor/src/components/timeline/TrackSidebar.tsx
@@ -19,6 +19,7 @@ const FIXED_TRACK_LABELS: Record<string, string> = {
   range: '',
   scene: 'Scenes',
   label: 'Labels',
+  audio: 'Audio',
   media: 'Media audio',
 };
 
@@ -156,7 +157,7 @@ export function TrackSidebar({
                 id={id}
                 name={labelFor(id)}
                 height={height}
-                resizable
+                resizable={id === 'media'}
               />
             );
           })}

--- a/packages/editor/src/components/timeline/TrackSidebar.tsx
+++ b/packages/editor/src/components/timeline/TrackSidebar.tsx
@@ -63,11 +63,21 @@ function TrackResizeHandle({id, label}: {id: TimelineTrackId; label: string}) {
   );
 }
 
-function MixButtons({name}: {name: string}) {
+function MixButtons({name, kind}: {name: string; kind: 'project' | 'media'}) {
   const {player} = useApplication();
   const state = usePlayerState();
-  const muted = state.projectAudioMuted;
-  const solo = state.projectAudioSolo;
+  const muted =
+    kind === 'media' ? state.mediaAudioMuted : state.projectAudioMuted;
+  const solo = kind === 'media' ? state.mediaAudioSolo : state.projectAudioSolo;
+
+  const toggleMuted = () =>
+    kind === 'media'
+      ? player.toggleMediaAudioMuted()
+      : player.toggleProjectAudioMuted();
+  const toggleSolo = () =>
+    kind === 'media'
+      ? player.toggleMediaAudioSolo()
+      : player.toggleProjectAudioSolo();
 
   return (
     <div className={styles.trackButtons}>
@@ -79,7 +89,7 @@ function MixButtons({name}: {name: string}) {
           styles.trackIconButton,
           muted && styles.trackButtonActive,
         )}
-        onClick={() => player.toggleProjectAudioMuted()}
+        onClick={toggleMuted}
       >
         {muted ? <VolumeOff /> : <VolumeOn />}
       </button>
@@ -87,7 +97,7 @@ function MixButtons({name}: {name: string}) {
         type="button"
         title={solo ? `Unsolo ${name}` : `Solo ${name}`}
         className={clsx(styles.trackButton, solo && styles.trackButtonActive)}
-        onClick={() => player.toggleProjectAudioSolo()}
+        onClick={toggleSolo}
       >
         S
       </button>
@@ -100,7 +110,7 @@ interface FixedTrackHeaderProps {
   name: string;
   height: number;
   resizable?: boolean;
-  mixable?: boolean;
+  mixKind?: 'project' | 'media';
 }
 
 function FixedTrackHeader({
@@ -108,7 +118,7 @@ function FixedTrackHeader({
   name,
   height,
   resizable,
-  mixable,
+  mixKind,
 }: FixedTrackHeaderProps) {
   return (
     <div
@@ -122,7 +132,7 @@ function FixedTrackHeader({
           <div className={styles.trackName} title={name}>
             {name}
           </div>
-          {mixable && <MixButtons name={name} />}
+          {mixKind && <MixButtons name={name} kind={mixKind} />}
         </div>
         {resizable && <TrackResizeHandle id={id} label={name} />}
       </div>
@@ -194,8 +204,8 @@ export function TrackSidebar({
                 id={id}
                 name={labelFor(id)}
                 height={height}
-                resizable={id === 'media'}
-                mixable={id === 'audio'}
+                resizable
+                mixKind={id === 'media' ? 'media' : 'project'}
               />
             );
           })}

--- a/packages/editor/src/components/timeline/TrackSidebar.tsx
+++ b/packages/editor/src/components/timeline/TrackSidebar.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx';
 import {useRef} from 'preact/hooks';
-import {useStorage} from '../../hooks';
+import {useApplication} from '../../contexts';
+import {usePlayerState, useStorage} from '../../hooks';
 import {MouseButton} from '../../utils';
+import {VolumeOff, VolumeOn} from '../icons';
 import {ChevronLeft} from '../icons/ChevronLeft';
 import {ChevronRight} from '../icons/ChevronRight';
 import styles from './Timeline.module.scss';
@@ -61,11 +63,44 @@ function TrackResizeHandle({id, label}: {id: TimelineTrackId; label: string}) {
   );
 }
 
+function MixButtons({name}: {name: string}) {
+  const {player} = useApplication();
+  const state = usePlayerState();
+  const muted = state.projectAudioMuted;
+  const solo = state.projectAudioSolo;
+
+  return (
+    <div className={styles.trackButtons}>
+      <button
+        type="button"
+        title={muted ? `Unmute ${name}` : `Mute ${name}`}
+        className={clsx(
+          styles.trackButton,
+          styles.trackIconButton,
+          muted && styles.trackButtonActive,
+        )}
+        onClick={() => player.toggleProjectAudioMuted()}
+      >
+        {muted ? <VolumeOff /> : <VolumeOn />}
+      </button>
+      <button
+        type="button"
+        title={solo ? `Unsolo ${name}` : `Solo ${name}`}
+        className={clsx(styles.trackButton, solo && styles.trackButtonActive)}
+        onClick={() => player.toggleProjectAudioSolo()}
+      >
+        S
+      </button>
+    </div>
+  );
+}
+
 interface FixedTrackHeaderProps {
   id: TimelineTrackId;
   name: string;
   height: number;
   resizable?: boolean;
+  mixable?: boolean;
 }
 
 function FixedTrackHeader({
@@ -73,6 +108,7 @@ function FixedTrackHeader({
   name,
   height,
   resizable,
+  mixable,
 }: FixedTrackHeaderProps) {
   return (
     <div
@@ -86,6 +122,7 @@ function FixedTrackHeader({
           <div className={styles.trackName} title={name}>
             {name}
           </div>
+          {mixable && <MixButtons name={name} />}
         </div>
         {resizable && <TrackResizeHandle id={id} label={name} />}
       </div>
@@ -158,6 +195,7 @@ export function TrackSidebar({
                 name={labelFor(id)}
                 height={height}
                 resizable={id === 'media'}
+                mixable={id === 'audio'}
               />
             );
           })}

--- a/packages/editor/src/components/timeline/TrackSidebar.tsx
+++ b/packages/editor/src/components/timeline/TrackSidebar.tsx
@@ -1,0 +1,167 @@
+import clsx from 'clsx';
+import {useRef} from 'preact/hooks';
+import {useStorage} from '../../hooks';
+import {MouseButton} from '../../utils';
+import {ChevronLeft} from '../icons/ChevronLeft';
+import {ChevronRight} from '../icons/ChevronRight';
+import styles from './Timeline.module.scss';
+import {
+  DEFAULT_WAVE_HEIGHT,
+  TRACK_ORDER_HEAD,
+  TRACK_ORDER_TAIL,
+  TimelineTrackId,
+  useTrackHeights,
+  useTrackScrollTop,
+  useWaveHeight,
+} from './trackLayout';
+
+const FIXED_TRACK_LABELS: Record<string, string> = {
+  range: '',
+  scene: 'Scenes',
+  label: 'Labels',
+  media: 'Media audio',
+};
+
+function labelFor(id: TimelineTrackId): string {
+  return FIXED_TRACK_LABELS[id] ?? '';
+}
+
+function TrackResizeHandle({id, label}: {id: TimelineTrackId; label: string}) {
+  const {height, setHeight} = useWaveHeight(id);
+  const dragRef = useRef<{y: number; height: number} | null>(null);
+
+  return (
+    <div
+      className={styles.trackResize}
+      data-track-resize={id}
+      title={`Resize ${label} (double-click to reset)`}
+      onPointerDown={event => {
+        if (event.button !== MouseButton.Left) return;
+        event.preventDefault();
+        event.stopPropagation();
+        event.currentTarget.setPointerCapture(event.pointerId);
+        dragRef.current = {y: event.clientY, height};
+      }}
+      onPointerMove={event => {
+        if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+        const drag = dragRef.current;
+        if (!drag) return;
+        event.stopPropagation();
+        setHeight(drag.height + (event.clientY - drag.y));
+      }}
+      onPointerUp={event => {
+        if (event.button !== MouseButton.Left) return;
+        event.stopPropagation();
+        event.currentTarget.releasePointerCapture(event.pointerId);
+        dragRef.current = null;
+      }}
+      onDblClick={() => setHeight(DEFAULT_WAVE_HEIGHT)}
+    />
+  );
+}
+
+interface FixedTrackHeaderProps {
+  id: TimelineTrackId;
+  name: string;
+  height: number;
+  resizable?: boolean;
+}
+
+function FixedTrackHeader({
+  id,
+  name,
+  height,
+  resizable,
+}: FixedTrackHeaderProps) {
+  return (
+    <div
+      className={styles.trackHeader}
+      data-track-header={id}
+      style={{height: `${height}px`}}
+    >
+      <div className={styles.trackAccent} />
+      <div className={styles.trackHeaderBody}>
+        <div className={styles.trackHeaderTop}>
+          <div className={styles.trackName} title={name}>
+            {name}
+          </div>
+        </div>
+        {resizable && <TrackResizeHandle id={id} label={name} />}
+      </div>
+    </div>
+  );
+}
+
+export function TrackSidebar({
+  onWheel,
+}: {
+  onWheel?: (event: WheelEvent) => void;
+}) {
+  const heights = useTrackHeights();
+  const scrollTop = useTrackScrollTop();
+  const [collapsed, setCollapsed] = useStorage(
+    'timeline-sidebar-collapsed',
+    false,
+  );
+
+  return (
+    <div
+      className={clsx(styles.sidebar, collapsed && styles.collapsed)}
+      data-track-sidebar
+      onWheel={onWheel}
+    >
+      <button
+        type="button"
+        className={styles.sidebarToggle}
+        data-sidebar-toggle
+        title={collapsed ? 'Show track sidebar' : 'Hide track sidebar'}
+        aria-expanded={!collapsed}
+        onClick={() => setCollapsed(!collapsed)}
+      >
+        {collapsed ? <ChevronRight /> : <ChevronLeft />}
+      </button>
+      {!collapsed && (
+        <div
+          className={styles.sidebarRows}
+          style={{transform: `translateY(${-scrollTop.value}px)`}}
+        >
+          {TRACK_ORDER_HEAD.map(id => {
+            const height = heights[id];
+            if (height === undefined) return null;
+            if (id === 'range') {
+              return (
+                <div
+                  key={id}
+                  data-track-header={id}
+                  style={{height: `${height}px`}}
+                />
+              );
+            }
+            return (
+              <FixedTrackHeader
+                key={id}
+                id={id}
+                name={labelFor(id)}
+                height={height}
+              />
+            );
+          })}
+
+          {TRACK_ORDER_TAIL.map(id => {
+            const height = heights[id];
+            if (height === undefined) return null;
+            return (
+              <FixedTrackHeader
+                key={id}
+                id={id}
+                name={labelFor(id)}
+                height={height}
+                resizable
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/editor/src/components/timeline/mediaSounds.ts
+++ b/packages/editor/src/components/timeline/mediaSounds.ts
@@ -1,0 +1,49 @@
+import type {Scene, Sound} from '@canvas-commons/core';
+import {useEffect, useState} from 'preact/hooks';
+
+export type MediaSound = Sound & {sourceKey: string};
+
+/**
+ * Deterministic color for a media clip, hashed from its source node's key so
+ * the same `Video` always gets the same waveform color.
+ */
+export function colorForKey(key: string): string {
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash << 5) - hash + key.charCodeAt(i);
+    hash |= 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, 70%, 65%)`;
+}
+
+/**
+ * Subscribes to every scene's sound list and returns just the media-derived
+ * ones (i.e. those with a `sourceKey`), combined across all scenes.
+ */
+export function useMediaSounds(scenes: readonly Scene[]): MediaSound[] {
+  const [sounds, setSounds] = useState<MediaSound[]>([]);
+
+  useEffect(() => {
+    const recompute = () => {
+      const combined: MediaSound[] = [];
+      for (const scene of scenes) {
+        for (const sound of scene.sounds.onChanged.current) {
+          const origin = sound.origin ?? (sound.sourceKey ? 'media' : 'audio');
+          if (sound.sourceKey && origin === 'media') {
+            combined.push(sound as MediaSound);
+          }
+        }
+      }
+      setSounds(combined);
+    };
+
+    recompute();
+    const unsubscribes = scenes.map(scene =>
+      scene.sounds.onChanged.subscribe(recompute),
+    );
+    return () => unsubscribes.forEach(unsubscribe => unsubscribe());
+  }, [scenes]);
+
+  return sounds;
+}

--- a/packages/editor/src/components/timeline/trackLayout.tsx
+++ b/packages/editor/src/components/timeline/trackLayout.tsx
@@ -4,19 +4,19 @@ import {useCallback, useContext, useLayoutEffect, useState} from 'preact/hooks';
 import {useStorage} from '../../hooks';
 import {clamp} from '../../utils';
 
-export type FixedTrackId = 'range' | 'scene' | 'label' | 'media';
+export type FixedTrackId = 'range' | 'scene' | 'label' | 'audio' | 'media';
 
 export type TimelineTrackId = FixedTrackId;
 
 export type TrackHeights = Partial<Record<string, number>>;
 
 export const TRACK_ORDER_HEAD: FixedTrackId[] = ['range', 'scene', 'label'];
-export const TRACK_ORDER_TAIL: FixedTrackId[] = ['media'];
+export const TRACK_ORDER_TAIL: FixedTrackId[] = ['audio', 'media'];
 
 /** Waveform fills the whole lane, so this is the lane height too. */
-export const DEFAULT_WAVE_HEIGHT = 96;
-export const MIN_WAVE_HEIGHT = 8;
-export const MAX_WAVE_HEIGHT = 480;
+export const DEFAULT_WAVE_HEIGHT = 32;
+export const MIN_WAVE_HEIGHT = 16;
+export const MAX_WAVE_HEIGHT = 256;
 
 export type WaveHeights = Partial<Record<string, number>>;
 

--- a/packages/editor/src/components/timeline/trackLayout.tsx
+++ b/packages/editor/src/components/timeline/trackLayout.tsx
@@ -1,0 +1,133 @@
+import {Signal, useSignal} from '@preact/signals';
+import {ComponentChildren, createContext} from 'preact';
+import {useCallback, useContext, useLayoutEffect, useState} from 'preact/hooks';
+import {useStorage} from '../../hooks';
+import {clamp} from '../../utils';
+
+export type FixedTrackId = 'range' | 'scene' | 'label' | 'media';
+
+export type TimelineTrackId = FixedTrackId;
+
+export type TrackHeights = Partial<Record<string, number>>;
+
+export const TRACK_ORDER_HEAD: FixedTrackId[] = ['range', 'scene', 'label'];
+export const TRACK_ORDER_TAIL: FixedTrackId[] = ['media'];
+
+/** Waveform fills the whole lane, so this is the lane height too. */
+export const DEFAULT_WAVE_HEIGHT = 96;
+export const MIN_WAVE_HEIGHT = 8;
+export const MAX_WAVE_HEIGHT = 480;
+
+export type WaveHeights = Partial<Record<string, number>>;
+
+interface TrackLayout {
+  heights: Signal<TrackHeights>;
+  /**
+   * Vertical scroll of the lane area, mirrored by the sidebar so its rows
+   * stay next to the lanes they label.
+   */
+  scrollTop: Signal<number>;
+  waveHeights: WaveHeights;
+  setWaveHeight: (id: TimelineTrackId, height: number) => void;
+}
+
+const TrackLayoutContext = createContext<TrackLayout>(null);
+
+export function TrackLayoutProvider({children}: {children: ComponentChildren}) {
+  const heights = useSignal<TrackHeights>({});
+  const scrollTop = useSignal(0);
+  const [waveHeights, setWaveHeights] = useStorage<WaveHeights>(
+    'timeline-wave-heights',
+    {},
+  );
+
+  const setWaveHeight = useCallback(
+    (id: TimelineTrackId, height: number) => {
+      setWaveHeights({
+        ...waveHeights,
+        [id]: clamp(MIN_WAVE_HEIGHT, MAX_WAVE_HEIGHT, Math.round(height)),
+      });
+    },
+    [waveHeights, setWaveHeights],
+  );
+
+  return (
+    <TrackLayoutContext.Provider
+      value={{heights, scrollTop, waveHeights, setWaveHeight}}
+    >
+      {children}
+    </TrackLayoutContext.Provider>
+  );
+}
+
+export function useTrackHeights(): TrackHeights {
+  return useContext(TrackLayoutContext).heights.value;
+}
+
+export function useTrackScrollTop(): Signal<number> {
+  return useContext(TrackLayoutContext).scrollTop;
+}
+
+/**
+ * Waveform height of an audio lane, and a setter used by the sidebar's
+ * resize handle.
+ */
+export function useWaveHeight(id: TimelineTrackId) {
+  const {waveHeights, setWaveHeight} = useContext(TrackLayoutContext);
+
+  return {
+    height: waveHeights[id] ?? DEFAULT_WAVE_HEIGHT,
+    setHeight: useCallback(
+      (height: number) => setWaveHeight(id, height),
+      [id, setWaveHeight],
+    ),
+  };
+}
+
+/**
+ * Report a lane's rendered height so the sidebar can mirror it.
+ *
+ * @remarks
+ * Lane heights are content-driven (the scene track grows with nested slides,
+ * the media lane disappears entirely without media audio), so the sidebar
+ * measures them instead of duplicating the layout rules. Returns a callback
+ * ref, so lanes that render conditionally drop their row as they unmount.
+ */
+export function useTrackLayout<T extends HTMLElement>(id: TimelineTrackId) {
+  const layout = useContext(TrackLayoutContext);
+  const heights = layout?.heights;
+  const [element, setElement] = useState<T | null>(null);
+
+  useLayoutEffect(() => {
+    if (!heights) return;
+
+    const forget = () => {
+      if (heights.value[id] === undefined) return;
+      const {[id]: _, ...rest} = heights.value;
+      heights.value = rest;
+    };
+
+    if (!element) {
+      forget();
+      return;
+    }
+
+    element.dataset.track = id;
+    const measure = () => {
+      const height = element.getBoundingClientRect().height;
+      if (heights.value[id] !== height) {
+        heights.value = {...heights.value, [id]: height};
+      }
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+      forget();
+    };
+  }, [id, element, heights]);
+
+  return useCallback((node: T | null) => setElement(node), []);
+}


### PR DESCRIPTION
## Pre-submission checks

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create one first).
- [ ] **Mandatory**: The issue has been accepted (indicated by a [`c-accepted`][label-accepted] label) and is assigned to me.
- [x] **Mandatory**: I have read and understood the [AI policy][ai-policy].
- [x] I hereby disclose the use of an LLM or other AI coding assistant in the creation of this PR. PRs will not be rejected for using AI tools, but *will* be rejected for undisclosed use or use that violates the policy. I have added an `Assisted-by: <tool name / model>` trailer to the commit message.

Closes #162

## Summary

Adds a timeline **track sidebar** and dedicated audio lanes, scoped to UI + the minimal `Sound` infrastructure needed to support it. Audio-system features (gain/fade envelopes, LUFS normalization, track mixing, ffmpeg audio export, standalone multi-track project audio management) are intentionally **out of scope** for this PR.

Lanes (top → bottom): **Scenes → Labels → Audio → Media audio**.

What's included:

- **Track sidebar** listing named, per-lane rows with resizable audio/media lanes (persisted heights).
- **Media audio lane**: auto-populates waveforms from `Video`-embedded audio via a lightweight `MediaAudioAnalyzer` (decode + peak scan to detect audible audio).
- **Project Audio lane**: shows user-authored voiceover / `Audio` / `sound()` clips with the existing shift-drag offset adjustment. Media audio is explicitly kept off this lane (distinguished by `Sound.origin`).
- **Mute/Solo** buttons on both the Audio and Media audio lanes, with cross-track solo semantics in the player.

Core changes (minimal, dependency-light):

- `Sound.origin` (`'media' | 'audio'`) + `sourceKey` so lanes can classify clips; `Sounds.add()` returns the registered sound and gains a `remove()`.
- Shared node-inspector key; `MediaAudioAnalyzer` + `dbToGain`/`gainToDb` helpers.
- Project/media `mute`/`solo` player state.
- Robustness fixes for async media duration (scheduling guard, recalc retry, non-negative duration clamp).

2d:

- `Video` registers its embedded audio as a media `Sound` for the timeline.

## Test Plan

- `pnpm --filter @canvas-commons/core run test` — 270 passing (covers sound origin/sourceKey/remove, media analyzer `hasAudio`, scheduling/duration robustness).
- `pnpm --filter @canvas-commons/2d run test` — 267 passing (covers `Video` media-audio registration, playback sync, CORS, duration).
- `pnpm --filter @canvas-commons/webcodecs run test` — 23 passing.
- `pnpm --filter @canvas-commons/editor exec tsc` and editor `build` — pass.
- Manual: verified in the editor that the sidebar lists Scenes/Labels/Audio/Media audio, media waveforms appear only on the Media audio lane, voiceover offset drag works, lanes resize, and Mute/Solo toggle each lane.

Assisted-by: Claude (Anthropic)

[ai-policy]: https://github.com/canvas-commons/.github/blob/main/AI_POLICY.md
[label-accepted]: https://github.com/canvas-commons/canvas-commons/issues?q=state%3Aopen%20label%3Ac-accepted
